### PR TITLE
feat: add MCPB desktop extension with user_config, proxy support, and env vars

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,3 +33,13 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build .mcpb bundles
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}" make mcpb
+
+      - name: Upload .mcpb bundles to release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ github.ref_name }}" ./build/mcpb/*.mcpb

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,9 +15,7 @@ builds:
     goarch:
       - amd64
       - arm64
-    ignore:
-      - goos: windows
-        goarch: arm64
+    # Windows arm64 is now supported for .mcpb bundles
 
 archives:
   - format: tar.gz

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,11 @@ VERSION?=dev
 # LDFLAGS
 LDFLAGS=-ldflags "-X main.version=${VERSION} -X main.gitCommit=${GIT_COMMIT} -X main.buildTime=${BUILD_TIME}"
 
-.PHONY: all build clean test test-unit test-integration check fmt lint vet help
+# MCPB targets
+MCPB_DIR=${BUILD_DIR}/mcpb
+MCPB_PLATFORMS=darwin/amd64 darwin/arm64 windows/amd64 windows/arm64
+
+.PHONY: all build clean test test-unit test-integration check fmt lint vet mcpb help
 
 # Default target
 all: clean check build
@@ -33,6 +37,7 @@ help:
 	@echo "  fmt            - Format code"
 	@echo "  vet            - Run go vet"
 	@echo "  lint           - Run linter"
+	@echo "  mcpb           - Build .mcpb bundles for all platforms"
 	@echo "  help           - Show this help"
 
 # Build the application
@@ -82,6 +87,10 @@ fmt:
 vet:
 	@echo "Running go vet..."
 	go vet ./...
+
+# Build .mcpb bundles for all platforms
+mcpb:
+	@VERSION=${VERSION} ./scripts/build-mcpb.sh
 
 # Run linter (requires golangci-lint)
 lint:

--- a/README.md
+++ b/README.md
@@ -20,6 +20,19 @@ MCP Remote proxies between:
 
 ## Installation
 
+### Desktop Extension (MCPB)
+
+Download the `.mcpb` file for your platform from [GitHub Releases](https://github.com/naotama2002/mcp-remote-go/releases):
+
+| Platform | File |
+|----------|------|
+| macOS (Apple Silicon) | `mcp-remote-go-darwin-arm64.mcpb` |
+| macOS (Intel) | `mcp-remote-go-darwin-amd64.mcpb` |
+| Windows (x64) | `mcp-remote-go-windows-amd64.mcpb` |
+| Windows (ARM64) | `mcp-remote-go-windows-arm64.mcpb` |
+
+Install by opening the `.mcpb` file in Claude Desktop. A configuration UI will appear where you can set the remote server URL and other options.
+
 ### Building from Source
 
 ```bash
@@ -74,6 +87,9 @@ mcp-remote-go https://remote.mcp.server/mcp --header "Authorization: Bearer YOUR
 
 # Allow HTTP for trusted networks (normally HTTPS is required)
 mcp-remote-go http://internal.mcp.server/mcp --allow-http
+
+# Via HTTP/HTTPS proxy
+mcp-remote-go https://remote.mcp.server/mcp --proxy http://proxy.example.com:8080
 ```
 
 ### Docker Usage
@@ -105,7 +121,20 @@ docker run --rm -it -p 3334:3334 -v ~/.mcp-remote-go-auth:/home/appuser/.mcp-rem
 
 By default, `mcp-remote-go` auto-detects the transport (Streamable HTTP or SSE). You can force a specific transport with the `--transport` flag.
 
-### Claude Desktop
+### Claude Desktop (MCPB Extension)
+
+The easiest way to use with Claude Desktop is via the `.mcpb` extension. After installing, configure through the GUI:
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| Remote MCP Server URL | The remote server URL (required) | — |
+| Transport Mode | `auto`, `streamable-http`, or `sse` | `auto` |
+| OAuth Callback Port | Local port for OAuth callback | `3334` |
+| Allow HTTP | Allow insecure HTTP connections | `false` |
+| HTTP/HTTPS Proxy | Proxy server URL (e.g. `http://proxy:8080`) | — |
+| Authorization Header | Auth header value (stored securely) | — |
+
+### Claude Desktop (Manual Configuration)
 
 Edit the configuration file at:
 - macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
@@ -245,6 +274,21 @@ Edit the configuration file at `~/.codeium/windsurf/mcp_config.json`:
   }
 }
 ```
+
+### Environment Variables
+
+All options can also be set via environment variables. CLI flags take precedence when both are set.
+
+| Variable | Description | Equivalent Flag |
+|----------|-------------|-----------------|
+| `MCP_SERVER_URL` | Remote MCP server URL | `--server` |
+| `MCP_TRANSPORT` | Transport mode (`auto`, `streamable-http`, `sse`) | `--transport` |
+| `MCP_PORT` | OAuth callback port | `--port` |
+| `MCP_ALLOW_HTTP` | Set to `true` to allow HTTP | `--allow-http` |
+| `MCP_PROXY` | HTTP/HTTPS proxy URL | `--proxy` |
+| `MCP_AUTH_HEADER` | Authorization header value | `--header "Authorization: ..."` |
+
+These environment variables are used internally by the MCPB extension to pass GUI-configured values to the binary.
 
 ## Authentication
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ mcp-remote-go https://remote.mcp.server/mcp --header "Authorization: Bearer YOUR
 mcp-remote-go http://internal.mcp.server/mcp --allow-http
 
 # Via HTTP/HTTPS proxy
-mcp-remote-go https://remote.mcp.server/mcp --proxy http://proxy.example.com:8080
+mcp-remote-go https://remote.mcp.server/mcp --https-proxy http://proxy.example.com:8080
 ```
 
 ### Docker Usage
@@ -285,7 +285,7 @@ All options can also be set via environment variables. CLI flags take precedence
 | `MCP_TRANSPORT` | Transport mode (`auto`, `streamable-http`, `sse`) | `--transport` |
 | `MCP_PORT` | OAuth callback port | `--port` |
 | `MCP_ALLOW_HTTP` | Set to `true` to allow HTTP | `--allow-http` |
-| `MCP_HTTPS_PROXY` | HTTP/HTTPS proxy URL | `--proxy` |
+| `MCP_HTTPS_PROXY` | HTTP/HTTPS proxy URL | `--https-proxy` |
 | `MCP_AUTH_HEADER` | Authorization header value | `--header "Authorization: ..."` |
 
 These environment variables are used internally by the MCPB extension to pass GUI-configured values to the binary.

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ All options can also be set via environment variables. CLI flags take precedence
 | `MCP_TRANSPORT` | Transport mode (`auto`, `streamable-http`, `sse`) | `--transport` |
 | `MCP_PORT` | OAuth callback port | `--port` |
 | `MCP_ALLOW_HTTP` | Set to `true` to allow HTTP | `--allow-http` |
-| `MCP_PROXY` | HTTP/HTTPS proxy URL | `--proxy` |
+| `MCP_HTTPS_PROXY` | HTTP/HTTPS proxy URL | `--proxy` |
 | `MCP_AUTH_HEADER` | Authorization header value | `--header "Authorization: ..."` |
 
 These environment variables are used internally by the MCPB extension to pass GUI-configured values to the binary.

--- a/cmd/mcp-remote-go/args_test.go
+++ b/cmd/mcp-remote-go/args_test.go
@@ -353,3 +353,42 @@ func TestApplyEnvOverrides_ProxyCLITakesPrecedence(t *testing.T) {
 		t.Errorf("CLI proxy should take precedence, got '%s'", httpProxy)
 	}
 }
+
+func TestApplyEnvOverrides_AllowHTTPCLITakesPrecedence(t *testing.T) {
+	t.Setenv("MCP_ALLOW_HTTP", "true")
+
+	serverURL := ""
+	port := 3334
+	allowHTTP := true // already set by CLI
+	transport := "auto"
+	httpProxy := ""
+	headers := flagList{}
+
+	applyEnvOverrides(&serverURL, &port, &allowHTTP, &transport, &httpProxy, &headers)
+
+	// Should remain true (CLI already set it)
+	if !allowHTTP {
+		t.Error("allowHTTP should remain true")
+	}
+}
+
+func TestApplyEnvOverrides_AuthHeaderCLITakesPrecedence(t *testing.T) {
+	t.Setenv("MCP_AUTH_HEADER", "Bearer env-token")
+
+	serverURL := ""
+	port := 3334
+	allowHTTP := false
+	transport := "auto"
+	httpProxy := ""
+	headers := flagList{"Authorization:Bearer cli-token"}
+
+	applyEnvOverrides(&serverURL, &port, &allowHTTP, &transport, &httpProxy, &headers)
+
+	// Should not add duplicate Authorization header
+	if len(headers) != 1 {
+		t.Errorf("Expected 1 header (CLI takes precedence), got %d: %v", len(headers), headers)
+	}
+	if headers[0] != "Authorization:Bearer cli-token" {
+		t.Errorf("Expected CLI auth header, got '%s'", headers[0])
+	}
+}

--- a/cmd/mcp-remote-go/args_test.go
+++ b/cmd/mcp-remote-go/args_test.go
@@ -296,8 +296,8 @@ func TestApplyEnvOverrides_NoEnvVars(t *testing.T) {
 	}
 }
 
-func TestParseRemainingArgs_ProxyAfterURL(t *testing.T) {
-	remaining := []string{"https://example.com/mcp", "--proxy", "http://proxy:8080"}
+func TestParseRemainingArgs_HttpsProxyAfterURL(t *testing.T) {
+	remaining := []string{"https://example.com/mcp", "--https-proxy", "http://proxy:8080"}
 	cfg := parseRemainingArgs(remaining, cliConfig{
 		callbackPort:  3334,
 		transportMode: "auto",
@@ -308,8 +308,8 @@ func TestParseRemainingArgs_ProxyAfterURL(t *testing.T) {
 	}
 }
 
-func TestParseRemainingArgs_ProxyEqualsForm(t *testing.T) {
-	remaining := []string{"https://example.com/mcp", "--proxy=http://proxy:3128"}
+func TestParseRemainingArgs_HttpsProxyEqualsForm(t *testing.T) {
+	remaining := []string{"https://example.com/mcp", "--https-proxy=http://proxy:3128"}
 	cfg := parseRemainingArgs(remaining, cliConfig{
 		callbackPort:  3334,
 		transportMode: "auto",

--- a/cmd/mcp-remote-go/args_test.go
+++ b/cmd/mcp-remote-go/args_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"os"
 	"testing"
 )
 
@@ -264,12 +263,12 @@ func TestApplyEnvOverrides_Port(t *testing.T) {
 }
 
 func TestApplyEnvOverrides_NoEnvVars(t *testing.T) {
-	os.Unsetenv("MCP_SERVER_URL")
-	os.Unsetenv("MCP_TRANSPORT")
-	os.Unsetenv("MCP_PORT")
-	os.Unsetenv("MCP_PROXY")
-	os.Unsetenv("MCP_ALLOW_HTTP")
-	os.Unsetenv("MCP_AUTH_HEADER")
+	t.Setenv("MCP_SERVER_URL", "")
+	t.Setenv("MCP_TRANSPORT", "")
+	t.Setenv("MCP_PORT", "")
+	t.Setenv("MCP_PROXY", "")
+	t.Setenv("MCP_ALLOW_HTTP", "")
+	t.Setenv("MCP_AUTH_HEADER", "")
 
 	serverURL := "https://original.com/mcp"
 	port := 3334

--- a/cmd/mcp-remote-go/args_test.go
+++ b/cmd/mcp-remote-go/args_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"testing"
 )
 
@@ -170,5 +171,186 @@ func TestParseRemainingArgs_SingleDashFlags(t *testing.T) {
 
 	if cfg.transportMode != "streamable-http" {
 		t.Errorf("Expected transport mode 'streamable-http', got '%s'", cfg.transportMode)
+	}
+}
+
+func TestApplyEnvOverrides_ServerURL(t *testing.T) {
+	t.Setenv("MCP_SERVER_URL", "https://env.example.com/mcp")
+
+	serverURL := ""
+	port := 3334
+	allowHTTP := false
+	transport := "auto"
+	headers := flagList{}
+
+	httpProxy := ""
+	applyEnvOverrides(&serverURL, &port, &allowHTTP, &transport, &httpProxy, &headers)
+
+	if serverURL != "https://env.example.com/mcp" {
+		t.Errorf("Expected server URL from env, got '%s'", serverURL)
+	}
+}
+
+func TestApplyEnvOverrides_CLITakesPrecedence(t *testing.T) {
+	t.Setenv("MCP_SERVER_URL", "https://env.example.com/mcp")
+	t.Setenv("MCP_TRANSPORT", "sse")
+
+	serverURL := "https://cli.example.com/mcp"
+	port := 3334
+	allowHTTP := false
+	transport := "streamable-http"
+	headers := flagList{}
+
+	httpProxy := ""
+	applyEnvOverrides(&serverURL, &port, &allowHTTP, &transport, &httpProxy, &headers)
+
+	if serverURL != "https://cli.example.com/mcp" {
+		t.Errorf("CLI server URL should take precedence, got '%s'", serverURL)
+	}
+	if transport != "streamable-http" {
+		t.Errorf("CLI transport should take precedence, got '%s'", transport)
+	}
+}
+
+func TestApplyEnvOverrides_AllowHTTP(t *testing.T) {
+	t.Setenv("MCP_ALLOW_HTTP", "true")
+
+	serverURL := ""
+	port := 3334
+	allowHTTP := false
+	transport := "auto"
+	headers := flagList{}
+
+	httpProxy := ""
+	applyEnvOverrides(&serverURL, &port, &allowHTTP, &transport, &httpProxy, &headers)
+
+	if !allowHTTP {
+		t.Error("Expected allowHTTP to be true from env")
+	}
+}
+
+func TestApplyEnvOverrides_AuthHeader(t *testing.T) {
+	t.Setenv("MCP_AUTH_HEADER", "Bearer secret-token")
+
+	serverURL := ""
+	port := 3334
+	allowHTTP := false
+	transport := "auto"
+	headers := flagList{}
+
+	httpProxy := ""
+	applyEnvOverrides(&serverURL, &port, &allowHTTP, &transport, &httpProxy, &headers)
+
+	if len(headers) != 1 || headers[0] != "Authorization:Bearer secret-token" {
+		t.Errorf("Expected Authorization header, got %v", headers)
+	}
+}
+
+func TestApplyEnvOverrides_Port(t *testing.T) {
+	t.Setenv("MCP_PORT", "9090")
+
+	serverURL := ""
+	port := 3334
+	allowHTTP := false
+	transport := "auto"
+	headers := flagList{}
+
+	httpProxy := ""
+	applyEnvOverrides(&serverURL, &port, &allowHTTP, &transport, &httpProxy, &headers)
+
+	if port != 9090 {
+		t.Errorf("Expected port 9090 from env, got %d", port)
+	}
+}
+
+func TestApplyEnvOverrides_NoEnvVars(t *testing.T) {
+	os.Unsetenv("MCP_SERVER_URL")
+	os.Unsetenv("MCP_TRANSPORT")
+	os.Unsetenv("MCP_PORT")
+	os.Unsetenv("MCP_PROXY")
+	os.Unsetenv("MCP_ALLOW_HTTP")
+	os.Unsetenv("MCP_AUTH_HEADER")
+
+	serverURL := "https://original.com/mcp"
+	port := 3334
+	allowHTTP := false
+	transport := "auto"
+	headers := flagList{}
+
+	httpProxy := ""
+	applyEnvOverrides(&serverURL, &port, &allowHTTP, &transport, &httpProxy, &headers)
+
+	if serverURL != "https://original.com/mcp" {
+		t.Errorf("Server URL should be unchanged, got '%s'", serverURL)
+	}
+	if port != 3334 {
+		t.Errorf("Port should be unchanged, got %d", port)
+	}
+	if allowHTTP {
+		t.Error("allowHTTP should be false")
+	}
+	if transport != "auto" {
+		t.Errorf("Transport should be unchanged, got '%s'", transport)
+	}
+	if len(headers) != 0 {
+		t.Errorf("Headers should be empty, got %v", headers)
+	}
+}
+
+func TestParseRemainingArgs_ProxyAfterURL(t *testing.T) {
+	remaining := []string{"https://example.com/mcp", "--proxy", "http://proxy:8080"}
+	cfg := parseRemainingArgs(remaining, cliConfig{
+		callbackPort:  3334,
+		transportMode: "auto",
+	})
+
+	if cfg.httpProxy != "http://proxy:8080" {
+		t.Errorf("Expected proxy 'http://proxy:8080', got '%s'", cfg.httpProxy)
+	}
+}
+
+func TestParseRemainingArgs_ProxyEqualsForm(t *testing.T) {
+	remaining := []string{"https://example.com/mcp", "--proxy=http://proxy:3128"}
+	cfg := parseRemainingArgs(remaining, cliConfig{
+		callbackPort:  3334,
+		transportMode: "auto",
+	})
+
+	if cfg.httpProxy != "http://proxy:3128" {
+		t.Errorf("Expected proxy 'http://proxy:3128', got '%s'", cfg.httpProxy)
+	}
+}
+
+func TestApplyEnvOverrides_Proxy(t *testing.T) {
+	t.Setenv("MCP_PROXY", "http://env-proxy:8080")
+
+	serverURL := ""
+	port := 3334
+	allowHTTP := false
+	transport := "auto"
+	httpProxy := ""
+	headers := flagList{}
+
+	applyEnvOverrides(&serverURL, &port, &allowHTTP, &transport, &httpProxy, &headers)
+
+	if httpProxy != "http://env-proxy:8080" {
+		t.Errorf("Expected proxy from env, got '%s'", httpProxy)
+	}
+}
+
+func TestApplyEnvOverrides_ProxyCLITakesPrecedence(t *testing.T) {
+	t.Setenv("MCP_PROXY", "http://env-proxy:8080")
+
+	serverURL := ""
+	port := 3334
+	allowHTTP := false
+	transport := "auto"
+	httpProxy := "http://cli-proxy:3128"
+	headers := flagList{}
+
+	applyEnvOverrides(&serverURL, &port, &allowHTTP, &transport, &httpProxy, &headers)
+
+	if httpProxy != "http://cli-proxy:3128" {
+		t.Errorf("CLI proxy should take precedence, got '%s'", httpProxy)
 	}
 }

--- a/cmd/mcp-remote-go/args_test.go
+++ b/cmd/mcp-remote-go/args_test.go
@@ -266,7 +266,7 @@ func TestApplyEnvOverrides_NoEnvVars(t *testing.T) {
 	t.Setenv("MCP_SERVER_URL", "")
 	t.Setenv("MCP_TRANSPORT", "")
 	t.Setenv("MCP_PORT", "")
-	t.Setenv("MCP_PROXY", "")
+	t.Setenv("MCP_HTTPS_PROXY", "")
 	t.Setenv("MCP_ALLOW_HTTP", "")
 	t.Setenv("MCP_AUTH_HEADER", "")
 
@@ -321,7 +321,7 @@ func TestParseRemainingArgs_ProxyEqualsForm(t *testing.T) {
 }
 
 func TestApplyEnvOverrides_Proxy(t *testing.T) {
-	t.Setenv("MCP_PROXY", "http://env-proxy:8080")
+	t.Setenv("MCP_HTTPS_PROXY", "http://env-proxy:8080")
 
 	serverURL := ""
 	port := 3334
@@ -338,7 +338,7 @@ func TestApplyEnvOverrides_Proxy(t *testing.T) {
 }
 
 func TestApplyEnvOverrides_ProxyCLITakesPrecedence(t *testing.T) {
-	t.Setenv("MCP_PROXY", "http://env-proxy:8080")
+	t.Setenv("MCP_HTTPS_PROXY", "http://env-proxy:8080")
 
 	serverURL := ""
 	port := 3334

--- a/cmd/mcp-remote-go/main.go
+++ b/cmd/mcp-remote-go/main.go
@@ -196,7 +196,7 @@ func applyEnvOverrides(serverURL *string, callbackPort *int, allowHTTP *bool, tr
 			log.Printf("Warning: failed to parse MCP_PORT: %v", err)
 		}
 	}
-	if v := os.Getenv("MCP_PROXY"); v != "" && *httpProxy == "" {
+	if v := os.Getenv("MCP_HTTPS_PROXY"); v != "" && *httpProxy == "" {
 		*httpProxy = v
 	}
 	if os.Getenv("MCP_ALLOW_HTTP") == "true" {

--- a/cmd/mcp-remote-go/main.go
+++ b/cmd/mcp-remote-go/main.go
@@ -19,12 +19,14 @@ func main() {
 	var callbackPort int
 	var allowHTTP bool
 	var transportMode string
+	var httpProxy string
 	var headers flagList
 
 	flag.StringVar(&serverURL, "server", "", "The MCP server URL to connect to")
 	flag.IntVar(&callbackPort, "port", 3334, "The callback port for OAuth")
 	flag.BoolVar(&allowHTTP, "allow-http", false, "Allow HTTP connections (only for trusted networks)")
 	flag.StringVar(&transportMode, "transport", "auto", "Transport mode: auto, streamable-http, sse")
+	flag.StringVar(&httpProxy, "proxy", "", "HTTP/HTTPS proxy URL (e.g. http://proxy:8080)")
 	flag.Var(&headers, "header", "Custom header to include in requests (format: 'Key:Value')")
 	flag.Parse()
 
@@ -35,16 +37,21 @@ func main() {
 		callbackPort:  callbackPort,
 		allowHTTP:     allowHTTP,
 		transportMode: transportMode,
+		httpProxy:     httpProxy,
 		headers:       []string(headers),
 	})
 	serverURL = cfg.serverURL
 	callbackPort = cfg.callbackPort
 	allowHTTP = cfg.allowHTTP
 	transportMode = cfg.transportMode
+	httpProxy = cfg.httpProxy
 	headers = flagList(cfg.headers)
 
+	// Environment variable overrides (used by MCPB user_config)
+	applyEnvOverrides(&serverURL, &callbackPort, &allowHTTP, &transportMode, &httpProxy, &headers)
+
 	if serverURL == "" {
-		fmt.Println("Usage: mcp-remote-go -server <server-url> [-port <callback-port>] [-allow-http] [-transport auto|streamable-http|sse] [-header 'Key:Value'] ...")
+		fmt.Println("Usage: mcp-remote-go -server <server-url> [-port <callback-port>] [-allow-http] [-transport auto|streamable-http|sse] [-proxy <proxy-url>] [-header 'Key:Value'] ...")
 		os.Exit(1)
 	}
 
@@ -75,7 +82,7 @@ func main() {
 	serverURLHash := getServerURLHash(serverURL)
 
 	// Create and start the proxy
-	p, err := proxy.NewProxyWithTransport(serverURL, callbackPort, headerMap, serverURLHash, mode)
+	p, err := proxy.NewProxyWithOptions(serverURL, callbackPort, headerMap, serverURLHash, mode, httpProxy)
 	if err != nil {
 		log.Fatalf("Failed to create proxy: %v", err)
 	}
@@ -121,6 +128,7 @@ type cliConfig struct {
 	callbackPort  int
 	allowHTTP     bool
 	transportMode string
+	httpProxy     string
 	headers       []string
 }
 
@@ -143,6 +151,11 @@ func parseRemainingArgs(remaining []string, defaults cliConfig) cliConfig {
 			i++
 		case strings.HasPrefix(arg, "--header=") || strings.HasPrefix(arg, "-header="):
 			cfg.headers = append(cfg.headers, strings.SplitN(arg, "=", 2)[1])
+		case (arg == "--proxy" || arg == "-proxy") && i+1 < len(remaining):
+			cfg.httpProxy = remaining[i+1]
+			i++
+		case strings.HasPrefix(arg, "--proxy=") || strings.HasPrefix(arg, "-proxy="):
+			cfg.httpProxy = strings.SplitN(arg, "=", 2)[1]
 		case arg == "--allow-http" || arg == "-allow-http":
 			cfg.allowHTTP = true
 		case (arg == "--port" || arg == "-port") && i+1 < len(remaining):
@@ -166,4 +179,30 @@ func parseRemainingArgs(remaining []string, defaults cliConfig) cliConfig {
 	}
 
 	return cfg
+}
+
+// applyEnvOverrides reads environment variables and applies them as overrides.
+// Environment variables are used by MCPB user_config to pass GUI-configured values.
+// CLI flags take precedence; env vars only apply when the corresponding flag is at its default.
+func applyEnvOverrides(serverURL *string, callbackPort *int, allowHTTP *bool, transportMode *string, httpProxy *string, headers *flagList) {
+	if v := os.Getenv("MCP_SERVER_URL"); v != "" && *serverURL == "" {
+		*serverURL = v
+	}
+	if v := os.Getenv("MCP_TRANSPORT"); v != "" && *transportMode == "auto" {
+		*transportMode = v
+	}
+	if v := os.Getenv("MCP_PORT"); v != "" && *callbackPort == 3334 {
+		if _, err := fmt.Sscanf(v, "%d", callbackPort); err != nil {
+			log.Printf("Warning: failed to parse MCP_PORT: %v", err)
+		}
+	}
+	if v := os.Getenv("MCP_PROXY"); v != "" && *httpProxy == "" {
+		*httpProxy = v
+	}
+	if os.Getenv("MCP_ALLOW_HTTP") == "true" {
+		*allowHTTP = true
+	}
+	if v := os.Getenv("MCP_AUTH_HEADER"); v != "" {
+		*headers = append(*headers, "Authorization:"+v)
+	}
 }

--- a/cmd/mcp-remote-go/main.go
+++ b/cmd/mcp-remote-go/main.go
@@ -14,7 +14,16 @@ import (
 	"github.com/naotama2002/mcp-remote-go/proxy"
 )
 
+// Build-time variables set via -ldflags.
+var (
+	version   = "dev"
+	gitCommit = "unknown"
+	buildTime = "unknown"
+)
+
 func main() {
+	log.Printf("mcp-remote-go version=%s commit=%s built=%s", version, gitCommit, buildTime)
+
 	var serverURL string
 	var callbackPort int
 	var allowHTTP bool
@@ -199,10 +208,19 @@ func applyEnvOverrides(serverURL *string, callbackPort *int, allowHTTP *bool, tr
 	if v := os.Getenv("MCP_HTTPS_PROXY"); v != "" && *httpProxy == "" {
 		*httpProxy = v
 	}
-	if os.Getenv("MCP_ALLOW_HTTP") == "true" {
+	if os.Getenv("MCP_ALLOW_HTTP") == "true" && !*allowHTTP {
 		*allowHTTP = true
 	}
 	if v := os.Getenv("MCP_AUTH_HEADER"); v != "" {
-		*headers = append(*headers, "Authorization:"+v)
+		hasAuth := false
+		for _, h := range *headers {
+			if strings.HasPrefix(strings.ToLower(h), "authorization:") {
+				hasAuth = true
+				break
+			}
+		}
+		if !hasAuth {
+			*headers = append(*headers, "Authorization:"+v)
+		}
 	}
 }

--- a/cmd/mcp-remote-go/main.go
+++ b/cmd/mcp-remote-go/main.go
@@ -26,7 +26,7 @@ func main() {
 	flag.IntVar(&callbackPort, "port", 3334, "The callback port for OAuth")
 	flag.BoolVar(&allowHTTP, "allow-http", false, "Allow HTTP connections (only for trusted networks)")
 	flag.StringVar(&transportMode, "transport", "auto", "Transport mode: auto, streamable-http, sse")
-	flag.StringVar(&httpProxy, "proxy", "", "HTTP/HTTPS proxy URL (e.g. http://proxy:8080)")
+	flag.StringVar(&httpProxy, "https-proxy", "", "HTTP/HTTPS proxy URL (e.g. http://proxy:8080)")
 	flag.Var(&headers, "header", "Custom header to include in requests (format: 'Key:Value')")
 	flag.Parse()
 
@@ -51,7 +51,7 @@ func main() {
 	applyEnvOverrides(&serverURL, &callbackPort, &allowHTTP, &transportMode, &httpProxy, &headers)
 
 	if serverURL == "" {
-		fmt.Println("Usage: mcp-remote-go -server <server-url> [-port <callback-port>] [-allow-http] [-transport auto|streamable-http|sse] [-proxy <proxy-url>] [-header 'Key:Value'] ...")
+		fmt.Println("Usage: mcp-remote-go -server <server-url> [-port <callback-port>] [-allow-http] [-transport auto|streamable-http|sse] [-https-proxy <proxy-url>] [-header 'Key:Value'] ...")
 		os.Exit(1)
 	}
 
@@ -151,10 +151,10 @@ func parseRemainingArgs(remaining []string, defaults cliConfig) cliConfig {
 			i++
 		case strings.HasPrefix(arg, "--header=") || strings.HasPrefix(arg, "-header="):
 			cfg.headers = append(cfg.headers, strings.SplitN(arg, "=", 2)[1])
-		case (arg == "--proxy" || arg == "-proxy") && i+1 < len(remaining):
+		case (arg == "--https-proxy" || arg == "-https-proxy") && i+1 < len(remaining):
 			cfg.httpProxy = remaining[i+1]
 			i++
-		case strings.HasPrefix(arg, "--proxy=") || strings.HasPrefix(arg, "-proxy="):
+		case strings.HasPrefix(arg, "--https-proxy=") || strings.HasPrefix(arg, "-https-proxy="):
 			cfg.httpProxy = strings.SplitN(arg, "=", 2)[1]
 		case arg == "--allow-http" || arg == "-allow-http":
 			cfg.allowHTTP = true

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -90,6 +90,8 @@ func NewProxyWithOptions(serverURL string, callbackPort int, headers map[string]
 }
 
 // buildHTTPClient creates an http.Client with optional proxy configuration.
+// When a proxy is configured, it clones http.DefaultTransport to preserve
+// HTTP/2, timeouts, and connection pooling defaults.
 func buildHTTPClient(proxyURL string) (*http.Client, error) {
 	if proxyURL == "" {
 		return &http.Client{}, nil
@@ -100,10 +102,18 @@ func buildHTTPClient(proxyURL string) (*http.Client, error) {
 		return nil, fmt.Errorf("invalid proxy URL %q: %w", proxyURL, err)
 	}
 
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return nil, fmt.Errorf("invalid proxy URL %q: scheme must be http or https", proxyURL)
+	}
+	if parsed.Host == "" {
+		return nil, fmt.Errorf("invalid proxy URL %q: missing host", proxyURL)
+	}
+
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.Proxy = http.ProxyURL(parsed)
+
 	return &http.Client{
-		Transport: &http.Transport{
-			Proxy: http.ProxyURL(parsed),
-		},
+		Transport: transport,
 	}, nil
 }
 

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -53,6 +53,11 @@ func NewProxy(serverURL string, callbackPort int, headers map[string]string, ser
 
 // NewProxyWithTransport creates a new MCP proxy with a specified transport mode
 func NewProxyWithTransport(serverURL string, callbackPort int, headers map[string]string, serverURLHash string, mode TransportMode) (*Proxy, error) {
+	return NewProxyWithOptions(serverURL, callbackPort, headers, serverURLHash, mode, "")
+}
+
+// NewProxyWithOptions creates a new MCP proxy with full configuration including HTTP proxy support
+func NewProxyWithOptions(serverURL string, callbackPort int, headers map[string]string, serverURLHash string, mode TransportMode, httpProxyURL string) (*Proxy, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	// Create auth coordinator
@@ -60,6 +65,13 @@ func NewProxyWithTransport(serverURL string, callbackPort int, headers map[strin
 	if err != nil {
 		cancel()
 		return nil, fmt.Errorf("failed to create auth coordinator: %w", err)
+	}
+
+	// Build HTTP client with optional proxy
+	httpClient, err := buildHTTPClient(httpProxyURL)
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("failed to configure HTTP proxy: %w", err)
 	}
 
 	return &Proxy{
@@ -71,9 +83,27 @@ func NewProxyWithTransport(serverURL string, callbackPort int, headers map[strin
 		authCoord:     authCoord,
 		ctx:           ctx,
 		cancel:        cancel,
-		client:        &http.Client{},
+		client:        httpClient,
 		stdioReader:   bufio.NewReader(os.Stdin),
 		stdioWriter:   bufio.NewWriter(os.Stdout),
+	}, nil
+}
+
+// buildHTTPClient creates an http.Client with optional proxy configuration.
+func buildHTTPClient(proxyURL string) (*http.Client, error) {
+	if proxyURL == "" {
+		return &http.Client{}, nil
+	}
+
+	parsed, err := url.Parse(proxyURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid proxy URL %q: %w", proxyURL, err)
+	}
+
+	return &http.Client{
+		Transport: &http.Transport{
+			Proxy: http.ProxyURL(parsed),
+		},
 	}, nil
 }
 

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -185,6 +185,20 @@ func TestBuildHTTPClient_InvalidProxyURL(t *testing.T) {
 	}
 }
 
+func TestBuildHTTPClient_MissingScheme(t *testing.T) {
+	_, err := buildHTTPClient("proxy:8080")
+	if err == nil {
+		t.Error("Expected error for proxy URL without http/https scheme")
+	}
+}
+
+func TestBuildHTTPClient_MissingHost(t *testing.T) {
+	_, err := buildHTTPClient("http://")
+	if err == nil {
+		t.Error("Expected error for proxy URL without host")
+	}
+}
+
 func TestNewProxyWithOptions_Proxy(t *testing.T) {
 	p, err := NewProxyWithOptions("https://example.com", 3334, map[string]string{}, "test-hash", TransportModeAuto, "http://proxy:8080")
 	if err != nil {

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -151,3 +151,51 @@ func TestProxyContext(t *testing.T) {
 		t.Error("Context should be cancelled")
 	}
 }
+
+func TestBuildHTTPClient_NoProxy(t *testing.T) {
+	client, err := buildHTTPClient("")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if client == nil {
+		t.Fatal("Client should not be nil")
+	}
+	if client.Transport != nil {
+		t.Error("Transport should be nil (default) when no proxy is set")
+	}
+}
+
+func TestBuildHTTPClient_WithProxy(t *testing.T) {
+	client, err := buildHTTPClient("http://proxy.example.com:8080")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if client == nil {
+		t.Fatal("Client should not be nil")
+	}
+	if client.Transport == nil {
+		t.Fatal("Transport should not be nil when proxy is set")
+	}
+}
+
+func TestBuildHTTPClient_InvalidProxyURL(t *testing.T) {
+	_, err := buildHTTPClient("://invalid")
+	if err == nil {
+		t.Error("Expected error for invalid proxy URL")
+	}
+}
+
+func TestNewProxyWithOptions_Proxy(t *testing.T) {
+	p, err := NewProxyWithOptions("https://example.com", 3334, map[string]string{}, "test-hash", TransportModeAuto, "http://proxy:8080")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	defer p.cancel()
+
+	if p.client == nil {
+		t.Fatal("HTTP client should not be nil")
+	}
+	if p.client.Transport == nil {
+		t.Fatal("HTTP transport should not be nil when proxy is configured")
+	}
+}

--- a/scripts/build-mcpb.sh
+++ b/scripts/build-mcpb.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BINARY_NAME="mcp-remote-go"
+MAIN_DIR="./cmd/mcp-remote-go"
+BUILD_DIR="./build"
+MCPB_DIR="${BUILD_DIR}/mcpb"
+VERSION="${VERSION:-dev}"
+GIT_COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+BUILD_TIME=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+LDFLAGS="-X main.version=${VERSION} -X main.gitCommit=${GIT_COMMIT} -X main.buildTime=${BUILD_TIME}"
+
+PLATFORMS=(
+  "darwin/amd64"
+  "darwin/arm64"
+  "windows/amd64"
+  "windows/arm64"
+)
+
+echo "Building .mcpb bundles (version: ${VERSION})..."
+mkdir -p "${MCPB_DIR}"
+
+for platform in "${PLATFORMS[@]}"; do
+  os="${platform%/*}"
+  arch="${platform#*/}"
+  echo "  Building ${os}/${arch}..."
+
+  bundle_dir="${MCPB_DIR}/${os}-${arch}"
+  mkdir -p "${bundle_dir}/server"
+
+  # Determine binary extension and platform name
+  ext=""
+  platform_name="${os}"
+  if [ "${os}" = "windows" ]; then
+    ext=".exe"
+    platform_name="win32"
+  fi
+
+  # Cross-compile
+  CGO_ENABLED=0 GOOS="${os}" GOARCH="${arch}" \
+    go build -trimpath -ldflags "${LDFLAGS}" \
+    -o "${bundle_dir}/server/${BINARY_NAME}${ext}" "${MAIN_DIR}"
+
+  # Generate manifest.json
+  cat > "${bundle_dir}/manifest.json" <<EOF
+{
+  "manifest_version": "0.3",
+  "name": "mcp-remote-go",
+  "display_name": "MCP Remote Go",
+  "version": "${VERSION}",
+  "description": "Proxy local MCP clients to remote MCP servers with Streamable HTTP and SSE transport support",
+  "author": {
+    "name": "naotama2002"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/naotama2002/mcp-remote-go"
+  },
+  "license": "MIT",
+  "server": {
+    "type": "binary",
+    "entry_point": "server/${BINARY_NAME}${ext}",
+    "mcp_config": {
+      "command": "\${__dirname}/server/${BINARY_NAME}${ext}",
+      "args": [
+        "--server", "\${user_config.server_url}",
+        "--transport", "\${user_config.transport}",
+        "--port", "\${user_config.port}"
+      ],
+      "env": {
+        "MCP_ALLOW_HTTP": "\${user_config.allow_http}",
+        "MCP_PROXY": "\${user_config.http_proxy}",
+        "MCP_AUTH_HEADER": "\${user_config.auth_header}"
+      }
+    }
+  },
+  "user_config": {
+    "server_url": {
+      "type": "string",
+      "title": "Remote MCP Server URL",
+      "description": "The remote MCP server URL to connect to (e.g. https://example.com/mcp)",
+      "required": true
+    },
+    "transport": {
+      "type": "string",
+      "title": "Transport Mode",
+      "description": "Transport protocol: auto (recommended), streamable-http, or sse",
+      "default": "auto"
+    },
+    "port": {
+      "type": "number",
+      "title": "OAuth Callback Port",
+      "description": "Local port for OAuth callback",
+      "default": 3334,
+      "min": 1024,
+      "max": 65535
+    },
+    "allow_http": {
+      "type": "boolean",
+      "title": "Allow HTTP",
+      "description": "Allow insecure HTTP connections (only for trusted networks)",
+      "default": false
+    },
+    "http_proxy": {
+      "type": "string",
+      "title": "HTTP/HTTPS Proxy",
+      "description": "Proxy server URL for HTTP/HTTPS connections (e.g. http://proxy:8080)"
+    },
+    "auth_header": {
+      "type": "string",
+      "title": "Authorization Header",
+      "description": "Custom Authorization header value (e.g. Bearer your-token-here)",
+      "sensitive": true
+    }
+  },
+  "compatibility": {
+    "platforms": ["${platform_name}"]
+  }
+}
+EOF
+
+  # Package as .mcpb (ZIP)
+  mcpb_file="${MCPB_DIR}/${BINARY_NAME}-${os}-${arch}.mcpb"
+  (cd "${bundle_dir}" && zip -qr - manifest.json server/) > "${mcpb_file}"
+
+  # Cleanup temp directory
+  rm -rf "${bundle_dir}"
+  echo "  Created: ${mcpb_file}"
+done
+
+echo ""
+echo "MCPB build complete. Files:"
+ls -lh "${MCPB_DIR}"/*.mcpb

--- a/scripts/build-mcpb.sh
+++ b/scripts/build-mcpb.sh
@@ -69,7 +69,7 @@ for platform in "${PLATFORMS[@]}"; do
       ],
       "env": {
         "MCP_ALLOW_HTTP": "\${user_config.allow_http}",
-        "MCP_PROXY": "\${user_config.http_proxy}",
+        "MCP_HTTPS_PROXY": "\${user_config.http_proxy}",
         "MCP_AUTH_HEADER": "\${user_config.auth_header}"
       }
     }


### PR DESCRIPTION
## Summary
- MCPB (.mcpb) バンドルビルドパイプラインを追加（darwin/amd64, darwin/arm64, windows/amd64, windows/arm64）
- Claude Desktop の GUI で設定可能な `user_config`（サーバURL、トランスポート、ポート、HTTP許可、プロキシ、認証ヘッダ）を manifest に定義
- `--https-proxy` フラグと `MCP_HTTPS_PROXY` 環境変数による HTTP/HTTPS プロキシサポートを追加
- 環境変数オーバーライド（`MCP_SERVER_URL`, `MCP_TRANSPORT`, `MCP_PORT`, `MCP_ALLOW_HTTP`, `MCP_HTTPS_PROXY`, `MCP_AUTH_HEADER`）を追加
- manifest の `repository` フィールドを MCPB 仕様準拠のオブジェクト形式に修正
- manifest の `command` パスに `${__dirname}` を使用しバイナリ解決を修正
- リリースワークフローで `.mcpb` バンドルを自動ビルド・アップロード

## Test plan
- [x] `go test ./cmd/mcp-remote-go/ -short` — CLI フラグ解析テスト、環境変数オーバーライドテスト、優先度テスト
- [x] `go test ./proxy/ -short -run "TestBuildHTTPClient|TestNewProxyWithOptions"` — HTTP proxy クライアント構築・検証テスト
- [x] `make lint` — 0 issues
- [x] `make mcpb` — 4プラットフォーム向け .mcpb ビルド成功
- [x] Claude Desktop で .mcpb インストール・設定 GUI 表示・接続確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)