### PR TITLE
fix: update .goreleaser.yml to v2 format

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,5 @@
+version: 2
+
 before:
   hooks:
     - go mod tidy
@@ -18,7 +20,8 @@ builds:
     # Windows arm64 is now supported for .mcpb bundles
 
 archives:
-  - format: tar.gz
+  - formats:
+      - tar.gz
     name_template: >-
       {{ .ProjectName }}_
       {{- title .Os }}_
@@ -27,13 +30,14 @@ archives:
       {{- else }}{{ .Arch }}{{ end }}
     format_overrides:
       - goos: windows
-        format: zip
+        formats:
+          - zip
 
 checksum:
   name_template: 'checksums.txt'
 
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  version_template: "{{ incpatch .Version }}-next"
 
 changelog:
   sort: asc


### PR DESCRIPTION
## Summary
- goreleaser v2 で必須の `version: 2` ヘッダを追加
- `format` → `formats`（リスト形式）に変更
- `snapshot.name_template` → `snapshot.version_template` に変更

v0.2.0 リリースで goreleaser が deprecation warnings を出していたため修正。

## Test plan
- [x] goreleaser v2 のスキーマに準拠していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)