### PR TITLE
fix: pin goreleaser to v2.14.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0
         with:
           distribution: goreleaser
-          version: latest
+          version: 'v2.14.2'
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- goreleaser のバージョンを `latest` から `v2.14.2` に固定
- 再現可能なビルドのため exact version を指定
- 今後のバージョン更新は Renovate が PR を出す

## Test plan
- [x] リリースワークフローは tag push 時にのみ実行されるため、マージ後の次回リリースで検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)