### PR TITLE
feat: MCP spec compliance — RFC 8707 resource indicator + RFC 9728 WWW-Authenticate

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ MCP Remote proxies between:
 - **Legacy SSE transport** (MCP 2024-11-05) - Traditional two-endpoint SSE connection
 - **Auto-negotiation** - Automatically detects server capabilities and selects the optimal transport
 - **OAuth 2.1 with PKCE** (RFC 7636) - Secure authorization with S256 code challenge
-- **Protected Resource Metadata** (RFC 9728) - Discover authorization servers from resource endpoints
+- **Protected Resource Metadata** (RFC 9728) - Discover authorization servers from resource endpoints, including `WWW-Authenticate`-driven discovery on 401 responses (§5.1)
+- **Resource Indicators** (RFC 8707) - The MCP server's canonical URI is sent as `resource` on both authorization and token requests
 - **OAuth Discovery** (RFC 8414) and OpenID Connect Discovery
 - **Custom headers** and HTTPS enforcement
 
@@ -296,7 +297,8 @@ The first time you connect to a server requiring authentication, you'll be promp
 
 The OAuth implementation supports:
 - **PKCE (RFC 7636)** with S256 code challenge for enhanced security
-- **Protected Resource Metadata (RFC 9728)** for discovering authorization servers
+- **Protected Resource Metadata (RFC 9728)** for discovering authorization servers, with `WWW-Authenticate`-driven PRM lookup on 401 (§5.1)
+- **Resource Indicators (RFC 8707)** — the MCP server's canonical URI is sent as `resource` on both authorization and token requests, as required by the MCP authorization spec
 - **OAuth 2.0 Authorization Server Metadata (RFC 8414)** and OpenID Connect Discovery
 
 Authorization tokens are stored in `~/.mcp-remote-go-auth/` and will be reused for future connections.

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -34,6 +34,10 @@ type ClientInfo struct {
 	ClientSecretExpiresAt   int64    `json:"client_secret_expires_at,omitempty"`
 	RedirectURIs            []string `json:"redirect_uris"`
 	TokenEndpointAuthMethod string   `json:"token_endpoint_auth_method,omitempty"`
+	// RegisteredIssuer is the authorization server issuer this client_id was
+	// registered with (RFC 8414 issuer). Used to invalidate stale cache when the
+	// discovered AS changes.
+	RegisteredIssuer string `json:"registered_issuer,omitempty"`
 }
 
 // ServerMetadata holds the OAuth server metadata
@@ -274,11 +278,15 @@ func (c *Coordinator) discoverServerMetadata(serverURL, resourceMetadataURL stri
 	return metadata, nil
 }
 
-// loadOrRegisterClient loads or registers a client
+// loadOrRegisterClient returns cached ClientInfo when it still matches the
+// currently-discovered authorization server (RFC 8414 issuer); otherwise it
+// performs RFC 7591 dynamic client registration. Issuer comparison covers the
+// WWW-Authenticate-driven discovery case where the AS may have changed without
+// changing the resource server URL, while still letting AS-with-no-DCR
+// configurations succeed via the cached static client_id.
 func (c *Coordinator) loadOrRegisterClient() (*ClientInfo, error) {
-	// First try to load existing client info
 	clientInfo, err := c.loadClientInfo()
-	if err == nil {
+	if err == nil && c.clientInfoMatchesServer(clientInfo) {
 		return clientInfo, nil
 	}
 
@@ -316,12 +324,27 @@ func (c *Coordinator) loadOrRegisterClient() (*ClientInfo, error) {
 		return nil, fmt.Errorf("failed to parse client registration response: %w", err)
 	}
 
+	if c.serverMetadata != nil {
+		clientInfoResp.RegisteredIssuer = c.serverMetadata.Issuer
+	}
+
 	// Save client info
 	if err := c.saveClientInfo(&clientInfoResp); err != nil {
 		return nil, fmt.Errorf("failed to save client info: %w", err)
 	}
 
 	return &clientInfoResp, nil
+}
+
+func (c *Coordinator) clientInfoMatchesServer(clientInfo *ClientInfo) bool {
+	if c.serverMetadata == nil || clientInfo == nil {
+		return true
+	}
+	if clientInfo.RegisteredIssuer == "" {
+		// Legacy cache entry without issuer; still usable.
+		return true
+	}
+	return clientInfo.RegisteredIssuer == c.serverMetadata.Issuer
 }
 
 // startCallbackServer starts the HTTP server to receive the OAuth callback.

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -55,9 +55,12 @@ type Coordinator struct {
 	callbackServer *http.Server
 	clientInfo     *ClientInfo
 	serverMetadata *ServerMetadata
-	codeVerifier   string // PKCE code_verifier for current auth flow
-	authMutex      sync.Mutex
-	callbackChan   chan string
+	// resource is the canonical URI of the MCP (resource) server, per RFC 8707,
+	// captured during InitializeAuth and reused in authorization and token requests.
+	resource     string
+	codeVerifier string // PKCE code_verifier for current auth flow
+	authMutex    sync.Mutex
+	callbackChan chan string
 }
 
 // NewCoordinator creates a new authentication coordinator
@@ -77,13 +80,43 @@ func NewCoordinator(serverURLHash string, callbackPort int) (*Coordinator, error
 	}, nil
 }
 
+// InitOption configures InitializeAuth.
+type InitOption func(*initConfig)
+
+type initConfig struct {
+	resourceMetadataURL string
+}
+
+// WithResourceMetadataURL passes a Protected Resource Metadata URL extracted
+// from a WWW-Authenticate header (RFC 9728 §5.1). When set, discovery uses
+// this URL directly instead of deriving one from the MCP server host.
+func WithResourceMetadataURL(url string) InitOption {
+	return func(c *initConfig) {
+		c.resourceMetadataURL = url
+	}
+}
+
 // InitializeAuth starts the OAuth flow
-func (c *Coordinator) InitializeAuth(serverURL string) (string, error) {
+func (c *Coordinator) InitializeAuth(serverURL string, opts ...InitOption) (string, error) {
 	c.authMutex.Lock()
 	defer c.authMutex.Unlock()
 
-	// 1. Discover server metadata
-	metadata, err := c.discoverServerMetadata(serverURL)
+	cfg := &initConfig{}
+	for _, o := range opts {
+		o(cfg)
+	}
+
+	// 0. Compute the canonical resource URI per RFC 8707. MCP clients MUST send
+	// this in both authorization and token requests regardless of AS support.
+	resource, err := CanonicalResourceURI(serverURL)
+	if err != nil {
+		return "", fmt.Errorf("failed to derive canonical resource URI: %w", err)
+	}
+	c.resource = resource
+
+	// 1. Discover server metadata, preferring the WWW-Authenticate-provided
+	//    PRM URL when present.
+	metadata, err := c.discoverServerMetadata(serverURL, cfg.resourceMetadataURL)
 	if err != nil {
 		return "", fmt.Errorf("failed to discover server metadata: %w", err)
 	}
@@ -135,6 +168,12 @@ func (c *Coordinator) ExchangeCode(code string) (*Tokens, error) {
 		"code":         code,
 		"redirect_uri": fmt.Sprintf("http://localhost:%d/callback", c.callbackPort),
 		"client_id":    c.clientInfo.ClientID,
+	}
+
+	// Resource Indicator (RFC 8707) — MUST be sent on the token request
+	// regardless of whether the AS supports it.
+	if c.resource != "" {
+		formData["resource"] = c.resource
 	}
 
 	// Add PKCE code_verifier
@@ -216,12 +255,18 @@ func (c *Coordinator) SaveTokens(tokens *Tokens) error {
 	})
 }
 
-// discoverServerMetadata discovers OAuth server metadata using multiple strategies
-func (c *Coordinator) discoverServerMetadata(serverURL string) (*ServerMetadata, error) {
-	// First try to load cached metadata
-	metadata, err := c.loadServerMetadata()
-	if err == nil {
-		return metadata, nil
+// discoverServerMetadata discovers OAuth server metadata using multiple
+// strategies. If resourceMetadataURL is non-empty, discovery first attempts
+// the Protected Resource Metadata document at that URL (e.g. one obtained
+// from a WWW-Authenticate header per RFC 9728 §5.1).
+func (c *Coordinator) discoverServerMetadata(serverURL, resourceMetadataURL string) (*ServerMetadata, error) {
+	// Don't reuse cached metadata when the caller supplied an explicit PRM
+	// URL: the cached entry may have been obtained through a different
+	// (less authoritative) path.
+	if resourceMetadataURL == "" {
+		if metadata, err := c.loadServerMetadata(); err == nil {
+			return metadata, nil
+		}
 	}
 
 	// Use the discovery service to find metadata
@@ -229,7 +274,7 @@ func (c *Coordinator) discoverServerMetadata(serverURL string) (*ServerMetadata,
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	metadata, err = discoveryService.Discover(ctx, serverURL)
+	metadata, err := discoveryService.Discover(ctx, serverURL, WithProtectedResourceMetadataURL(resourceMetadataURL))
 	if err != nil {
 		return nil, fmt.Errorf("failed to discover server metadata: %w", err)
 	}
@@ -383,6 +428,12 @@ func (c *Coordinator) buildAuthorizationURL() (string, error) {
 	params.Set("scope", "mcp offline_access")
 	params.Set("code_challenge", ComputeCodeChallenge(verifier))
 	params.Set("code_challenge_method", "S256")
+
+	// Resource Indicator (RFC 8707) — MUST be sent on the authorization
+	// request regardless of whether the AS supports it.
+	if c.resource != "" {
+		params.Set("resource", c.resource)
+	}
 
 	// Combine URL
 	baseURL, err := url.Parse(c.serverMetadata.AuthorizationEndpoint)

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -55,12 +55,10 @@ type Coordinator struct {
 	callbackServer *http.Server
 	clientInfo     *ClientInfo
 	serverMetadata *ServerMetadata
-	// resource is the canonical URI of the MCP (resource) server, per RFC 8707,
-	// captured during InitializeAuth and reused in authorization and token requests.
-	resource     string
-	codeVerifier string // PKCE code_verifier for current auth flow
-	authMutex    sync.Mutex
-	callbackChan chan string
+	resource       string // RFC 8707 canonical resource URI, reused across the flow
+	codeVerifier   string
+	authMutex      sync.Mutex
+	callbackChan   chan string
 }
 
 // NewCoordinator creates a new authentication coordinator
@@ -80,7 +78,6 @@ func NewCoordinator(serverURLHash string, callbackPort int) (*Coordinator, error
 	}, nil
 }
 
-// InitOption configures InitializeAuth.
 type InitOption func(*initConfig)
 
 type initConfig struct {
@@ -88,8 +85,8 @@ type initConfig struct {
 }
 
 // WithResourceMetadataURL passes a Protected Resource Metadata URL extracted
-// from a WWW-Authenticate header (RFC 9728 §5.1). When set, discovery uses
-// this URL directly instead of deriving one from the MCP server host.
+// from a WWW-Authenticate header (RFC 9728 §5.1); when set, discovery fetches
+// it directly instead of deriving a URL from the MCP server host.
 func WithResourceMetadataURL(url string) InitOption {
 	return func(c *initConfig) {
 		c.resourceMetadataURL = url
@@ -106,16 +103,12 @@ func (c *Coordinator) InitializeAuth(serverURL string, opts ...InitOption) (stri
 		o(cfg)
 	}
 
-	// 0. Compute the canonical resource URI per RFC 8707. MCP clients MUST send
-	// this in both authorization and token requests regardless of AS support.
 	resource, err := CanonicalResourceURI(serverURL)
 	if err != nil {
 		return "", fmt.Errorf("failed to derive canonical resource URI: %w", err)
 	}
 	c.resource = resource
 
-	// 1. Discover server metadata, preferring the WWW-Authenticate-provided
-	//    PRM URL when present.
 	metadata, err := c.discoverServerMetadata(serverURL, cfg.resourceMetadataURL)
 	if err != nil {
 		return "", fmt.Errorf("failed to discover server metadata: %w", err)
@@ -170,8 +163,7 @@ func (c *Coordinator) ExchangeCode(code string) (*Tokens, error) {
 		"client_id":    c.clientInfo.ClientID,
 	}
 
-	// Resource Indicator (RFC 8707) — MUST be sent on the token request
-	// regardless of whether the AS supports it.
+	// RFC 8707 resource indicator (required by the MCP authorization spec).
 	if c.resource != "" {
 		formData["resource"] = c.resource
 	}
@@ -255,14 +247,9 @@ func (c *Coordinator) SaveTokens(tokens *Tokens) error {
 	})
 }
 
-// discoverServerMetadata discovers OAuth server metadata using multiple
-// strategies. If resourceMetadataURL is non-empty, discovery first attempts
-// the Protected Resource Metadata document at that URL (e.g. one obtained
-// from a WWW-Authenticate header per RFC 9728 §5.1).
 func (c *Coordinator) discoverServerMetadata(serverURL, resourceMetadataURL string) (*ServerMetadata, error) {
-	// Don't reuse cached metadata when the caller supplied an explicit PRM
-	// URL: the cached entry may have been obtained through a different
-	// (less authoritative) path.
+	// Skip cache when the caller supplied an explicit PRM URL: the cached
+	// entry may have come from a different (less authoritative) path.
 	if resourceMetadataURL == "" {
 		if metadata, err := c.loadServerMetadata(); err == nil {
 			return metadata, nil
@@ -429,8 +416,7 @@ func (c *Coordinator) buildAuthorizationURL() (string, error) {
 	params.Set("code_challenge", ComputeCodeChallenge(verifier))
 	params.Set("code_challenge_method", "S256")
 
-	// Resource Indicator (RFC 8707) — MUST be sent on the authorization
-	// request regardless of whether the AS supports it.
+	// RFC 8707 resource indicator (required by the MCP authorization spec).
 	if c.resource != "" {
 		params.Set("resource", c.resource)
 	}

--- a/auth/client_cache_test.go
+++ b/auth/client_cache_test.go
@@ -1,0 +1,117 @@
+package auth
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func newCoordinatorWithCachedClient(t *testing.T, hash string, port int, info ClientInfo) *Coordinator {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+
+	coordinator, err := NewCoordinator(hash, port)
+	if err != nil {
+		t.Fatalf("NewCoordinator failed: %v", err)
+	}
+	if err := coordinator.saveClientInfo(&info); err != nil {
+		t.Fatalf("saveClientInfo failed: %v", err)
+	}
+	return coordinator
+}
+
+func TestLoadOrRegisterClientSkipsStaleCacheForDifferentIssuer(t *testing.T) {
+	coordinator := newCoordinatorWithCachedClient(t, "client-cache-issuer-test", 3350, ClientInfo{
+		ClientID:         "stale-client-id",
+		RegisteredIssuer: "https://old-as.example.com",
+		RedirectURIs:     []string{"http://localhost:3350/callback"},
+	})
+
+	var registerHits int
+	as := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/register" {
+			registerHits++
+			info := ClientInfo{
+				ClientID:                "fresh-client-id",
+				RedirectURIs:            []string{"http://localhost:3350/callback"},
+				TokenEndpointAuthMethod: "none",
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(info)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer as.Close()
+
+	coordinator.serverMetadata = &ServerMetadata{
+		Issuer:               as.URL,
+		RegistrationEndpoint: as.URL + "/register",
+	}
+
+	clientInfo, err := coordinator.loadOrRegisterClient()
+	if err != nil {
+		t.Fatalf("loadOrRegisterClient failed: %v", err)
+	}
+	if registerHits != 1 {
+		t.Fatalf("expected dynamic registration once, got %d hits", registerHits)
+	}
+	if clientInfo.ClientID != "fresh-client-id" {
+		t.Errorf("ClientID = %q, want fresh-client-id", clientInfo.ClientID)
+	}
+	if clientInfo.RegisteredIssuer != as.URL {
+		t.Errorf("RegisteredIssuer = %q, want %q", clientInfo.RegisteredIssuer, as.URL)
+	}
+}
+
+// TestLoadOrRegisterClientReusesCacheWhenIssuerMatches guards against the
+// regression where 401 re-auth on an authorization server without RFC 7591
+// dynamic client registration (no registration_endpoint) would fail because
+// the cache was skipped despite the cached client_id still being valid.
+func TestLoadOrRegisterClientReusesCacheWhenIssuerMatches(t *testing.T) {
+	const issuer = "https://as.example.com"
+	coordinator := newCoordinatorWithCachedClient(t, "client-cache-reuse-test", 3351, ClientInfo{
+		ClientID:         "preregistered-static",
+		RegisteredIssuer: issuer,
+		RedirectURIs:     []string{"http://localhost:3351/callback"},
+	})
+
+	// No registration_endpoint: if the cache is incorrectly bypassed, the
+	// call must fail with "server does not support dynamic registration".
+	coordinator.serverMetadata = &ServerMetadata{
+		Issuer:                issuer,
+		AuthorizationEndpoint: issuer + "/authorize",
+		TokenEndpoint:         issuer + "/token",
+	}
+
+	clientInfo, err := coordinator.loadOrRegisterClient()
+	if err != nil {
+		t.Fatalf("loadOrRegisterClient failed: %v", err)
+	}
+	if clientInfo.ClientID != "preregistered-static" {
+		t.Errorf("ClientID = %q, want preregistered-static", clientInfo.ClientID)
+	}
+}
+
+// TestLoadOrRegisterClientReusesLegacyCacheWithoutIssuer guards backwards
+// compatibility: pre-existing cache files without RegisteredIssuer are still
+// usable so a tool upgrade does not force a re-registration on every server.
+func TestLoadOrRegisterClientReusesLegacyCacheWithoutIssuer(t *testing.T) {
+	coordinator := newCoordinatorWithCachedClient(t, "client-cache-legacy-test", 3352, ClientInfo{
+		ClientID:     "legacy-client",
+		RedirectURIs: []string{"http://localhost:3352/callback"},
+	})
+
+	coordinator.serverMetadata = &ServerMetadata{
+		Issuer: "https://as.example.com",
+	}
+
+	clientInfo, err := coordinator.loadOrRegisterClient()
+	if err != nil {
+		t.Fatalf("loadOrRegisterClient failed: %v", err)
+	}
+	if clientInfo.ClientID != "legacy-client" {
+		t.Errorf("ClientID = %q, want legacy-client", clientInfo.ClientID)
+	}
+}

--- a/auth/discovery.go
+++ b/auth/discovery.go
@@ -164,11 +164,11 @@ func (p *ProtectedResourceDiscovery) Name() string {
 func (p *ProtectedResourceDiscovery) Discover(ctx context.Context, serverURL string) (*ServerMetadata, error) {
 	wellKnownURL := p.metadataURL
 	if wellKnownURL == "" {
-		parsed, err := url.Parse(serverURL)
+		var err error
+		wellKnownURL, err = ProtectedResourceWellKnownURL(serverURL)
 		if err != nil {
 			return nil, fmt.Errorf("invalid server URL: %w", err)
 		}
-		wellKnownURL = fmt.Sprintf("%s://%s/.well-known/oauth-protected-resource", parsed.Scheme, parsed.Host)
 	} else {
 		// The PRM URL came from an untrusted WWW-Authenticate header; reject
 		// non-absolute or non-http(s) values rather than fetching them.
@@ -186,6 +186,10 @@ func (p *ProtectedResourceDiscovery) Discover(ctx context.Context, serverURL str
 	var prm ProtectedResourceMetadata
 	if err := resp.JSON(&prm); err != nil {
 		return nil, fmt.Errorf("failed to parse protected resource metadata from %s: %w", wellKnownURL, err)
+	}
+
+	if err := ValidatePRMResource(prm.Resource, serverURL); err != nil {
+		return nil, err
 	}
 
 	if len(prm.AuthorizationServers) == 0 {

--- a/auth/discovery.go
+++ b/auth/discovery.go
@@ -119,6 +119,20 @@ func (o *OpenIDConnectDiscovery) fetchMetadata(ctx context.Context, metadataURL 
 	return &metadata, nil
 }
 
+func validatePRMURL(raw string) error {
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("invalid protected resource metadata URL %q: %w", raw, err)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return fmt.Errorf("protected resource metadata URL %q must use http or https scheme", raw)
+	}
+	if parsed.Host == "" {
+		return fmt.Errorf("protected resource metadata URL %q must include a host", raw)
+	}
+	return nil
+}
+
 // ProtectedResourceMetadata holds RFC 9728 Protected Resource Metadata
 type ProtectedResourceMetadata struct {
 	Resource             string   `json:"resource"`
@@ -155,6 +169,12 @@ func (p *ProtectedResourceDiscovery) Discover(ctx context.Context, serverURL str
 			return nil, fmt.Errorf("invalid server URL: %w", err)
 		}
 		wellKnownURL = fmt.Sprintf("%s://%s/.well-known/oauth-protected-resource", parsed.Scheme, parsed.Host)
+	} else {
+		// The PRM URL came from an untrusted WWW-Authenticate header; reject
+		// non-absolute or non-http(s) values rather than fetching them.
+		if err := validatePRMURL(wellKnownURL); err != nil {
+			return nil, err
+		}
 	}
 
 	resp, err := p.client.Get(ctx, wellKnownURL, nil)

--- a/auth/discovery.go
+++ b/auth/discovery.go
@@ -127,24 +127,15 @@ type ProtectedResourceMetadata struct {
 }
 
 // ProtectedResourceDiscovery implements RFC 9728 Protected Resource Metadata discovery.
-// It fetches /.well-known/oauth-protected-resource from the resource server to find
-// the authorization server(s), then fetches OAuth metadata from those servers.
 type ProtectedResourceDiscovery struct {
-	client httpclient.Client
-	// metadataURL overrides the derived /.well-known/oauth-protected-resource
-	// URL. When set (typically from a WWW-Authenticate header), discovery
-	// fetches this URL directly.
-	metadataURL string
+	client      httpclient.Client
+	metadataURL string // when set, used verbatim instead of deriving from the server host
 }
 
-// NewProtectedResourceDiscovery creates a new RFC 9728 discovery strategy that
-// derives the PRM URL from the server host.
 func NewProtectedResourceDiscovery(client httpclient.Client) *ProtectedResourceDiscovery {
 	return &ProtectedResourceDiscovery{client: client}
 }
 
-// NewProtectedResourceDiscoveryFromURL creates an RFC 9728 discovery strategy
-// that fetches an explicit PRM URL (e.g. one obtained from WWW-Authenticate).
 func NewProtectedResourceDiscoveryFromURL(client httpclient.Client, metadataURL string) *ProtectedResourceDiscovery {
 	return &ProtectedResourceDiscovery{client: client, metadataURL: metadataURL}
 }
@@ -236,17 +227,14 @@ func (f *FallbackDiscovery) Discover(ctx context.Context, serverURL string) (*Se
 	}, nil
 }
 
-// DiscoverOption configures Discover.
 type DiscoverOption func(*discoverConfig)
 
 type discoverConfig struct {
 	protectedResourceMetadataURL string
 }
 
-// WithProtectedResourceMetadataURL provides an explicit Protected Resource
-// Metadata URL (typically obtained from a WWW-Authenticate header per
-// RFC 9728 §5.1). When set, the discovery service fetches that URL directly
-// rather than deriving one from the MCP server's host.
+// WithProtectedResourceMetadataURL passes an explicit Protected Resource
+// Metadata URL (typically from a WWW-Authenticate header per RFC 9728 §5.1).
 func WithProtectedResourceMetadataURL(url string) DiscoverOption {
 	return func(c *discoverConfig) {
 		c.protectedResourceMetadataURL = url
@@ -262,12 +250,14 @@ func (m *MetadataDiscoveryService) Discover(ctx context.Context, serverURL strin
 
 	var strategies []DiscoveryStrategy
 	if cfg.protectedResourceMetadataURL != "" {
-		// When a PRM URL is supplied (e.g. from WWW-Authenticate), try it
-		// first and trust it as the authoritative source.
+		// RFC 9728 §5.1: the WWW-Authenticate-supplied URL is authoritative,
+		// so skip the host-derived PRM lookup (which could point at a
+		// different, less trustworthy document on the resource host).
 		strategies = append(strategies, NewProtectedResourceDiscoveryFromURL(m.client, cfg.protectedResourceMetadataURL))
+	} else {
+		strategies = append(strategies, NewProtectedResourceDiscovery(m.client))
 	}
 	strategies = append(strategies,
-		NewProtectedResourceDiscovery(m.client),
 		NewStandardOAuthDiscovery(m.client),
 		NewOpenIDConnectDiscovery(m.client),
 		NewFallbackDiscovery(),

--- a/auth/discovery.go
+++ b/auth/discovery.go
@@ -131,25 +131,40 @@ type ProtectedResourceMetadata struct {
 // the authorization server(s), then fetches OAuth metadata from those servers.
 type ProtectedResourceDiscovery struct {
 	client httpclient.Client
+	// metadataURL overrides the derived /.well-known/oauth-protected-resource
+	// URL. When set (typically from a WWW-Authenticate header), discovery
+	// fetches this URL directly.
+	metadataURL string
 }
 
-// NewProtectedResourceDiscovery creates a new RFC 9728 discovery strategy
+// NewProtectedResourceDiscovery creates a new RFC 9728 discovery strategy that
+// derives the PRM URL from the server host.
 func NewProtectedResourceDiscovery(client httpclient.Client) *ProtectedResourceDiscovery {
 	return &ProtectedResourceDiscovery{client: client}
 }
 
+// NewProtectedResourceDiscoveryFromURL creates an RFC 9728 discovery strategy
+// that fetches an explicit PRM URL (e.g. one obtained from WWW-Authenticate).
+func NewProtectedResourceDiscoveryFromURL(client httpclient.Client, metadataURL string) *ProtectedResourceDiscovery {
+	return &ProtectedResourceDiscovery{client: client, metadataURL: metadataURL}
+}
+
 func (p *ProtectedResourceDiscovery) Name() string {
+	if p.metadataURL != "" {
+		return "Protected Resource Metadata via WWW-Authenticate (RFC 9728)"
+	}
 	return "Protected Resource Metadata (RFC 9728)"
 }
 
 func (p *ProtectedResourceDiscovery) Discover(ctx context.Context, serverURL string) (*ServerMetadata, error) {
-	parsed, err := url.Parse(serverURL)
-	if err != nil {
-		return nil, fmt.Errorf("invalid server URL: %w", err)
+	wellKnownURL := p.metadataURL
+	if wellKnownURL == "" {
+		parsed, err := url.Parse(serverURL)
+		if err != nil {
+			return nil, fmt.Errorf("invalid server URL: %w", err)
+		}
+		wellKnownURL = fmt.Sprintf("%s://%s/.well-known/oauth-protected-resource", parsed.Scheme, parsed.Host)
 	}
-
-	// Fetch /.well-known/oauth-protected-resource
-	wellKnownURL := fmt.Sprintf("%s://%s/.well-known/oauth-protected-resource", parsed.Scheme, parsed.Host)
 
 	resp, err := p.client.Get(ctx, wellKnownURL, nil)
 	if err != nil {
@@ -221,14 +236,42 @@ func (f *FallbackDiscovery) Discover(ctx context.Context, serverURL string) (*Se
 	}, nil
 }
 
+// DiscoverOption configures Discover.
+type DiscoverOption func(*discoverConfig)
+
+type discoverConfig struct {
+	protectedResourceMetadataURL string
+}
+
+// WithProtectedResourceMetadataURL provides an explicit Protected Resource
+// Metadata URL (typically obtained from a WWW-Authenticate header per
+// RFC 9728 §5.1). When set, the discovery service fetches that URL directly
+// rather than deriving one from the MCP server's host.
+func WithProtectedResourceMetadataURL(url string) DiscoverOption {
+	return func(c *discoverConfig) {
+		c.protectedResourceMetadataURL = url
+	}
+}
+
 // Discover tries multiple discovery strategies in order
-func (m *MetadataDiscoveryService) Discover(ctx context.Context, serverURL string) (*ServerMetadata, error) {
-	strategies := []DiscoveryStrategy{
+func (m *MetadataDiscoveryService) Discover(ctx context.Context, serverURL string, opts ...DiscoverOption) (*ServerMetadata, error) {
+	cfg := &discoverConfig{}
+	for _, o := range opts {
+		o(cfg)
+	}
+
+	var strategies []DiscoveryStrategy
+	if cfg.protectedResourceMetadataURL != "" {
+		// When a PRM URL is supplied (e.g. from WWW-Authenticate), try it
+		// first and trust it as the authoritative source.
+		strategies = append(strategies, NewProtectedResourceDiscoveryFromURL(m.client, cfg.protectedResourceMetadataURL))
+	}
+	strategies = append(strategies,
 		NewProtectedResourceDiscovery(m.client),
 		NewStandardOAuthDiscovery(m.client),
 		NewOpenIDConnectDiscovery(m.client),
 		NewFallbackDiscovery(),
-	}
+	)
 
 	var lastErr error
 	for _, strategy := range strategies {

--- a/auth/discovery_prm_resource_test.go
+++ b/auth/discovery_prm_resource_test.go
@@ -1,0 +1,94 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/naotama2002/mcp-remote-go/internal/httpclient"
+)
+
+func TestProtectedResourceDiscoveryPathBasedWellKnown(t *testing.T) {
+	const serverPath = "/mcp"
+
+	var authServer *httptest.Server
+	authServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/.well-known/oauth-authorization-server" {
+			meta := ServerMetadata{
+				Issuer:                authServer.URL,
+				AuthorizationEndpoint: authServer.URL + "/authorize",
+				TokenEndpoint:         authServer.URL + "/token",
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(meta)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer authServer.Close()
+
+	serverURL := ""
+	resourceServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/.well-known/oauth-protected-resource/mcp" {
+			prm := ProtectedResourceMetadata{
+				Resource:             serverURL,
+				AuthorizationServers: []string{authServer.URL},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(prm)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer resourceServer.Close()
+
+	canonicalURL, err := CanonicalResourceURI(resourceServer.URL + serverPath)
+	if err != nil {
+		t.Fatalf("CanonicalResourceURI: %v", err)
+	}
+	serverURL = canonicalURL
+
+	strategy := NewProtectedResourceDiscovery(*httpclient.New(nil))
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	metadata, err := strategy.Discover(ctx, serverURL)
+	if err != nil {
+		t.Fatalf("Discover failed: %v", err)
+	}
+	if metadata.AuthorizationEndpoint != authServer.URL+"/authorize" {
+		t.Errorf("AuthorizationEndpoint = %q", metadata.AuthorizationEndpoint)
+	}
+}
+
+func TestProtectedResourceDiscoveryRejectsMismatchedResource(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/.well-known/oauth-protected-resource" {
+			prm := ProtectedResourceMetadata{
+				Resource:             "https://other.example.com",
+				AuthorizationServers: []string{"https://as.example.com"},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(prm)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	strategy := NewProtectedResourceDiscovery(*httpclient.New(nil))
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := strategy.Discover(ctx, server.URL)
+	if err == nil {
+		t.Fatal("expected error for mismatched PRM resource")
+	}
+	if !strings.Contains(err.Error(), "does not match") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/auth/discovery_prm_url_test.go
+++ b/auth/discovery_prm_url_test.go
@@ -1,0 +1,60 @@
+package auth
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/naotama2002/mcp-remote-go/internal/httpclient"
+)
+
+// TestProtectedResourceDiscoveryRejectsInvalidPRMURL verifies that an
+// attacker-supplied WWW-Authenticate `resource_metadata` value pointing at a
+// non-absolute or non-http(s) URL is rejected before any fetch happens.
+func TestProtectedResourceDiscoveryRejectsInvalidPRMURL(t *testing.T) {
+	tests := []struct {
+		name   string
+		url    string
+		errSub string
+	}{
+		{
+			name:   "relative URL",
+			url:    "/some/path",
+			errSub: "scheme",
+		},
+		{
+			name:   "ftp scheme",
+			url:    "ftp://example.com/prm",
+			errSub: "scheme",
+		},
+		{
+			name:   "file scheme",
+			url:    "file:///etc/passwd",
+			errSub: "scheme",
+		},
+		{
+			name:   "javascript scheme",
+			url:    "javascript:alert(1)",
+			errSub: "scheme",
+		},
+		{
+			name:   "scheme without host",
+			url:    "https://",
+			errSub: "host",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := httpclient.New(nil)
+			disco := NewProtectedResourceDiscoveryFromURL(*client, tt.url)
+			_, err := disco.Discover(context.Background(), "https://mcp.example.com")
+			if err == nil {
+				t.Fatalf("expected error for %q, got nil", tt.url)
+			}
+			if !strings.Contains(err.Error(), tt.errSub) {
+				t.Errorf("error %q does not mention %q", err.Error(), tt.errSub)
+			}
+		})
+	}
+}

--- a/auth/discovery_test.go
+++ b/auth/discovery_test.go
@@ -254,11 +254,12 @@ func TestProtectedResourceDiscovery(t *testing.T) {
 
 func TestProtectedResourceDiscoveryFallback(t *testing.T) {
 	// Resource server returns protected resource metadata, but auth server is unreachable
+	var resourceURL string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/.well-known/oauth-protected-resource":
 			prm := &ProtectedResourceMetadata{
-				Resource:             "https://example.com",
+				Resource:             resourceURL,
 				AuthorizationServers: []string{"https://unreachable.example.com"},
 			}
 			w.Header().Set("Content-Type", "application/json")
@@ -272,6 +273,7 @@ func TestProtectedResourceDiscoveryFallback(t *testing.T) {
 		}
 	}))
 	defer server.Close()
+	resourceURL = server.URL
 
 	service := NewMetadataDiscoveryService()
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -292,10 +294,11 @@ func TestProtectedResourceDiscoveryFallback(t *testing.T) {
 func TestProtectedResourceDiscoveryNoAuthServers(t *testing.T) {
 	strategy := NewProtectedResourceDiscovery(*httpclient.New(nil))
 
+	var resourceURL string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/.well-known/oauth-protected-resource" {
 			prm := &ProtectedResourceMetadata{
-				Resource:             "https://example.com",
+				Resource:             resourceURL,
 				AuthorizationServers: []string{}, // empty
 			}
 			w.Header().Set("Content-Type", "application/json")
@@ -303,6 +306,7 @@ func TestProtectedResourceDiscoveryNoAuthServers(t *testing.T) {
 		}
 	}))
 	defer server.Close()
+	resourceURL = server.URL
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()

--- a/auth/resource_indicator_test.go
+++ b/auth/resource_indicator_test.go
@@ -1,0 +1,139 @@
+package auth
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestResourceParameterSentInAuthAndTokenRequests verifies that the MCP-required
+// `resource` parameter (RFC 8707) is included in both the authorization request
+// and the token exchange, and that it carries the canonical URI of the MCP server.
+func TestResourceParameterSentInAuthAndTokenRequests(t *testing.T) {
+	authCode := "code-resource-test"
+
+	var tokenFormResource atomic.Value // string
+	tokenFormResource.Store("")
+
+	var mockServer *httptest.Server
+	mockServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/oauth-authorization-server":
+			metadata := ServerMetadata{
+				Issuer:                mockServer.URL,
+				AuthorizationEndpoint: mockServer.URL + "/auth",
+				TokenEndpoint:         mockServer.URL + "/token",
+				RegistrationEndpoint:  mockServer.URL + "/register",
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(metadata)
+
+		case "/register":
+			clientInfo := ClientInfo{
+				ClientID:                "resource-client",
+				RedirectURIs:            []string{"http://localhost:3344/callback"},
+				TokenEndpointAuthMethod: "none",
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(clientInfo)
+
+		case "/token":
+			if err := r.ParseForm(); err != nil {
+				http.Error(w, "parse form failed", http.StatusBadRequest)
+				return
+			}
+			tokenFormResource.Store(r.Form.Get("resource"))
+
+			tokens := Tokens{
+				AccessToken: "access-token",
+				TokenType:   "Bearer",
+				ExpiresIn:   3600,
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(tokens)
+
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer mockServer.Close()
+
+	// Isolate config directory.
+	tmpDir := t.TempDir()
+	originalHome := os.Getenv("HOME")
+	defer func() { _ = os.Setenv("HOME", originalHome) }()
+	_ = os.Setenv("HOME", tmpDir)
+
+	coordinator, err := NewCoordinator("resource-test-hash", 3344)
+	if err != nil {
+		t.Fatalf("NewCoordinator failed: %v", err)
+	}
+
+	// Use uppercase / trailing slash to also exercise canonicalization.
+	rawServerURL := mockServer.URL + "/"
+	expectedResource, err := CanonicalResourceURI(rawServerURL)
+	if err != nil {
+		t.Fatalf("CanonicalResourceURI failed: %v", err)
+	}
+
+	authURL, err := coordinator.InitializeAuth(rawServerURL)
+	if err != nil {
+		t.Fatalf("InitializeAuth failed: %v", err)
+	}
+
+	parsed, err := url.Parse(authURL)
+	if err != nil {
+		t.Fatalf("invalid auth URL: %v", err)
+	}
+	if got := parsed.Query().Get("resource"); got != expectedResource {
+		t.Errorf("authorization URL resource param = %q, want %q (auth URL: %s)", got, expectedResource, authURL)
+	}
+
+	// Exchange the code and verify the token request carried the same resource.
+	if _, err := coordinator.ExchangeCode(authCode); err != nil {
+		t.Fatalf("ExchangeCode failed: %v", err)
+	}
+
+	// Allow a brief moment in case net/http handlers are not yet flushed
+	// (in practice the response is already returned before we get here).
+	deadline := time.Now().Add(1 * time.Second)
+	for time.Now().Before(deadline) {
+		if v, _ := tokenFormResource.Load().(string); v != "" {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	got, _ := tokenFormResource.Load().(string)
+	if got != expectedResource {
+		t.Errorf("token request resource param = %q, want %q", got, expectedResource)
+	}
+}
+
+// TestResourceParameterRejectsInvalidServerURL ensures InitializeAuth fails
+// fast on URLs that cannot produce a canonical resource identifier.
+func TestResourceParameterRejectsInvalidServerURL(t *testing.T) {
+	tmpDir := t.TempDir()
+	originalHome := os.Getenv("HOME")
+	defer func() { _ = os.Setenv("HOME", originalHome) }()
+	_ = os.Setenv("HOME", tmpDir)
+
+	coordinator, err := NewCoordinator("invalid-url-test", 3345)
+	if err != nil {
+		t.Fatalf("NewCoordinator failed: %v", err)
+	}
+
+	_, err = coordinator.InitializeAuth("https://example.com#frag")
+	if err == nil {
+		t.Fatal("expected error for URL containing fragment")
+	}
+	if !strings.Contains(err.Error(), "canonical resource URI") {
+		t.Errorf("expected canonical-URI error, got: %v", err)
+	}
+}

--- a/auth/resource_metadata_url_test.go
+++ b/auth/resource_metadata_url_test.go
@@ -1,0 +1,112 @@
+package auth
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync/atomic"
+	"testing"
+)
+
+// TestInitializeAuthUsesResourceMetadataURL verifies that when a Protected
+// Resource Metadata URL is supplied (typically obtained from a 401's
+// WWW-Authenticate header per RFC 9728 §5.1), discovery fetches that exact
+// URL instead of deriving /.well-known/oauth-protected-resource from the
+// MCP server host.
+func TestInitializeAuthUsesResourceMetadataURL(t *testing.T) {
+	var (
+		prmHits          atomic.Int32
+		wellKnownPRMHits atomic.Int32
+		oauthHits        atomic.Int32
+	)
+
+	// Resource server: returns 404 on the conventional well-known PRM path.
+	// If discovery falls back to host-derived PRM lookup we will see hits
+	// here instead of the explicit metadataURL handler.
+	resourceServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/oauth-protected-resource":
+			wellKnownPRMHits.Add(1)
+			http.NotFound(w, r)
+		case "/.well-known/oauth-authorization-server":
+			// Fallback path; should not be hit when explicit PRM URL works.
+			oauthHits.Add(1)
+			http.NotFound(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer resourceServer.Close()
+
+	// Authorization server: hosts both an unconventional PRM URL (the one
+	// advertised via WWW-Authenticate) and its own RFC 8414 metadata.
+	var authServer *httptest.Server
+	authServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/custom/protected-resource.json":
+			prmHits.Add(1)
+			prm := ProtectedResourceMetadata{
+				Resource:             resourceServer.URL,
+				AuthorizationServers: []string{authServer.URL},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(prm)
+
+		case "/.well-known/oauth-authorization-server":
+			meta := ServerMetadata{
+				Issuer:                authServer.URL,
+				AuthorizationEndpoint: authServer.URL + "/auth",
+				TokenEndpoint:         authServer.URL + "/token",
+				RegistrationEndpoint:  authServer.URL + "/register",
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(meta)
+
+		case "/register":
+			info := ClientInfo{
+				ClientID:                "via-www-authenticate",
+				RedirectURIs:            []string{"http://localhost:3346/callback"},
+				TokenEndpointAuthMethod: "none",
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(info)
+
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer authServer.Close()
+
+	tmpDir := t.TempDir()
+	originalHome := os.Getenv("HOME")
+	defer func() { _ = os.Setenv("HOME", originalHome) }()
+	_ = os.Setenv("HOME", tmpDir)
+
+	coordinator, err := NewCoordinator("prm-url-hint-test", 3346)
+	if err != nil {
+		t.Fatalf("NewCoordinator failed: %v", err)
+	}
+
+	prmURL := authServer.URL + "/custom/protected-resource.json"
+	authURL, err := coordinator.InitializeAuth(resourceServer.URL, WithResourceMetadataURL(prmURL))
+	if err != nil {
+		t.Fatalf("InitializeAuth failed: %v", err)
+	}
+	if authURL == "" {
+		t.Fatal("expected non-empty authorization URL")
+	}
+
+	if prmHits.Load() == 0 {
+		t.Errorf("expected the supplied PRM URL %q to be fetched, but it was never hit", prmURL)
+	}
+	if wellKnownPRMHits.Load() != 0 {
+		t.Errorf("did not expect host-derived PRM lookup, but got %d hit(s) on resource server's .well-known", wellKnownPRMHits.Load())
+	}
+
+	// The authorization endpoint must come from the AS metadata we
+	// reached via the supplied PRM URL.
+	if coordinator.serverMetadata == nil || coordinator.serverMetadata.AuthorizationEndpoint != authServer.URL+"/auth" {
+		t.Errorf("AuthorizationEndpoint = %q, want %q", coordinator.serverMetadata.AuthorizationEndpoint, authServer.URL+"/auth")
+	}
+}

--- a/auth/resource_uri.go
+++ b/auth/resource_uri.go
@@ -6,34 +6,27 @@ import (
 	"strings"
 )
 
-// CanonicalResourceURI returns the canonical URI of an MCP server as defined by
-// the MCP authorization specification and RFC 8707.
-//
-// Rules:
-//   - Scheme and host are lowercased.
-//   - Fragment is rejected (invalid per the MCP spec).
-//   - Scheme and host must be present.
-//   - A trailing slash on the path is removed unless the path is exactly "/".
-//   - Query string is preserved verbatim (RFC 8707 does not forbid it, though
-//     servers typically use path-only identifiers).
-func CanonicalResourceURI(serverURL string) (string, error) {
+// canonicalResourceURL returns the canonical *url.URL of an MCP server per the
+// MCP authorization specification and RFC 8707 (lowercased scheme/host, no
+// fragment, no trailing slash on the path, query preserved).
+func canonicalResourceURL(serverURL string) (*url.URL, error) {
 	if serverURL == "" {
-		return "", fmt.Errorf("server URL is empty")
+		return nil, fmt.Errorf("server URL is empty")
 	}
 
 	parsed, err := url.Parse(serverURL)
 	if err != nil {
-		return "", fmt.Errorf("invalid server URL: %w", err)
+		return nil, fmt.Errorf("invalid server URL: %w", err)
 	}
 
 	if parsed.Scheme == "" {
-		return "", fmt.Errorf("server URL missing scheme: %s", serverURL)
+		return nil, fmt.Errorf("server URL missing scheme: %s", serverURL)
 	}
 	if parsed.Host == "" {
-		return "", fmt.Errorf("server URL missing host: %s", serverURL)
+		return nil, fmt.Errorf("server URL missing host: %s", serverURL)
 	}
 	if parsed.Fragment != "" || strings.Contains(serverURL, "#") {
-		return "", fmt.Errorf("server URL must not contain a fragment: %s", serverURL)
+		return nil, fmt.Errorf("server URL must not contain a fragment: %s", serverURL)
 	}
 
 	canonical := &url.URL{
@@ -48,6 +41,66 @@ func CanonicalResourceURI(serverURL string) (string, error) {
 	if canonical.Path == "/" {
 		canonical.Path = ""
 	}
+	return canonical, nil
+}
 
-	return canonical.String(), nil
+// CanonicalResourceURI returns the canonical URI of an MCP server as defined by
+// the MCP authorization specification and RFC 8707.
+//
+// Rules:
+//   - Scheme and host are lowercased.
+//   - Fragment is rejected (invalid per the MCP spec).
+//   - Scheme and host must be present.
+//   - A trailing slash on the path is removed unless the path is exactly "/".
+//   - Query string is preserved verbatim (RFC 8707 does not forbid it, though
+//     servers typically use path-only identifiers).
+func CanonicalResourceURI(serverURL string) (string, error) {
+	u, err := canonicalResourceURL(serverURL)
+	if err != nil {
+		return "", err
+	}
+	return u.String(), nil
+}
+
+const protectedResourceWellKnownSuffix = "/.well-known/oauth-protected-resource"
+
+// ProtectedResourceWellKnownURL builds the RFC 9728 §3.1 metadata URL for a
+// resource identifier (the MCP server URL).
+func ProtectedResourceWellKnownURL(serverURL string) (string, error) {
+	u, err := canonicalResourceURL(serverURL)
+	if err != nil {
+		return "", err
+	}
+
+	out := u.Scheme + "://" + u.Host + protectedResourceWellKnownSuffix + u.Path
+	if u.RawQuery != "" {
+		out += "?" + u.RawQuery
+	}
+	return out, nil
+}
+
+// ValidatePRMResource ensures PRM resource matches the MCP server per RFC 9728 §3.3.
+func ValidatePRMResource(prmResource, serverURL string) error {
+	if strings.TrimSpace(prmResource) == "" {
+		return fmt.Errorf("protected resource metadata missing required resource field")
+	}
+
+	expected, err := CanonicalResourceURI(serverURL)
+	if err != nil {
+		return fmt.Errorf("invalid server URL for PRM validation: %w", err)
+	}
+
+	// Common fast path: the server already advertised the canonical form.
+	if prmResource == expected {
+		return nil
+	}
+
+	actual, err := CanonicalResourceURI(prmResource)
+	if err != nil {
+		return fmt.Errorf("protected resource metadata resource %q does not match MCP server %q", prmResource, expected)
+	}
+	if actual != expected {
+		return fmt.Errorf("protected resource metadata resource %q does not match MCP server %q", actual, expected)
+	}
+	return nil
 }

--- a/auth/resource_uri.go
+++ b/auth/resource_uri.go
@@ -42,12 +42,9 @@ func CanonicalResourceURI(serverURL string) (string, error) {
 		Path:     parsed.Path,
 		RawQuery: parsed.RawQuery,
 	}
-
-	// Strip trailing slash unless the path is just "/".
 	if len(canonical.Path) > 1 && strings.HasSuffix(canonical.Path, "/") {
 		canonical.Path = strings.TrimRight(canonical.Path, "/")
 	}
-	// "/" alone carries no information; drop it for consistency.
 	if canonical.Path == "/" {
 		canonical.Path = ""
 	}

--- a/auth/resource_uri.go
+++ b/auth/resource_uri.go
@@ -1,0 +1,56 @@
+package auth
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// CanonicalResourceURI returns the canonical URI of an MCP server as defined by
+// the MCP authorization specification and RFC 8707.
+//
+// Rules:
+//   - Scheme and host are lowercased.
+//   - Fragment is rejected (invalid per the MCP spec).
+//   - Scheme and host must be present.
+//   - A trailing slash on the path is removed unless the path is exactly "/".
+//   - Query string is preserved verbatim (RFC 8707 does not forbid it, though
+//     servers typically use path-only identifiers).
+func CanonicalResourceURI(serverURL string) (string, error) {
+	if serverURL == "" {
+		return "", fmt.Errorf("server URL is empty")
+	}
+
+	parsed, err := url.Parse(serverURL)
+	if err != nil {
+		return "", fmt.Errorf("invalid server URL: %w", err)
+	}
+
+	if parsed.Scheme == "" {
+		return "", fmt.Errorf("server URL missing scheme: %s", serverURL)
+	}
+	if parsed.Host == "" {
+		return "", fmt.Errorf("server URL missing host: %s", serverURL)
+	}
+	if parsed.Fragment != "" || strings.Contains(serverURL, "#") {
+		return "", fmt.Errorf("server URL must not contain a fragment: %s", serverURL)
+	}
+
+	canonical := &url.URL{
+		Scheme:   strings.ToLower(parsed.Scheme),
+		Host:     strings.ToLower(parsed.Host),
+		Path:     parsed.Path,
+		RawQuery: parsed.RawQuery,
+	}
+
+	// Strip trailing slash unless the path is just "/".
+	if len(canonical.Path) > 1 && strings.HasSuffix(canonical.Path, "/") {
+		canonical.Path = strings.TrimRight(canonical.Path, "/")
+	}
+	// "/" alone carries no information; drop it for consistency.
+	if canonical.Path == "/" {
+		canonical.Path = ""
+	}
+
+	return canonical.String(), nil
+}

--- a/auth/resource_uri_test.go
+++ b/auth/resource_uri_test.go
@@ -1,0 +1,91 @@
+package auth
+
+import "testing"
+
+func TestCanonicalResourceURI(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:  "simple https",
+			input: "https://mcp.example.com",
+			want:  "https://mcp.example.com",
+		},
+		{
+			name:  "with path",
+			input: "https://mcp.example.com/mcp",
+			want:  "https://mcp.example.com/mcp",
+		},
+		{
+			name:  "with port",
+			input: "https://mcp.example.com:8443",
+			want:  "https://mcp.example.com:8443",
+		},
+		{
+			name:  "uppercase scheme and host normalised",
+			input: "HTTPS://MCP.Example.COM/Mcp",
+			want:  "https://mcp.example.com/Mcp",
+		},
+		{
+			name:  "trailing slash on root stripped",
+			input: "https://mcp.example.com/",
+			want:  "https://mcp.example.com",
+		},
+		{
+			name:  "trailing slash on subpath stripped",
+			input: "https://mcp.example.com/mcp/",
+			want:  "https://mcp.example.com/mcp",
+		},
+		{
+			name:  "nested path preserved",
+			input: "https://mcp.example.com/server/mcp",
+			want:  "https://mcp.example.com/server/mcp",
+		},
+		{
+			name:  "query preserved",
+			input: "https://mcp.example.com/mcp?tenant=acme",
+			want:  "https://mcp.example.com/mcp?tenant=acme",
+		},
+		{
+			name:    "missing scheme",
+			input:   "mcp.example.com",
+			wantErr: true,
+		},
+		{
+			name:    "with fragment",
+			input:   "https://mcp.example.com#fragment",
+			wantErr: true,
+		},
+		{
+			name:    "empty",
+			input:   "",
+			wantErr: true,
+		},
+		{
+			name:    "scheme only",
+			input:   "https://",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := CanonicalResourceURI(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q, got %q", tt.input, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for %q: %v", tt.input, err)
+			}
+			if got != tt.want {
+				t.Errorf("CanonicalResourceURI(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/auth/resource_uri_test.go
+++ b/auth/resource_uri_test.go
@@ -89,3 +89,84 @@ func TestCanonicalResourceURI(t *testing.T) {
 		})
 	}
 }
+
+func TestProtectedResourceWellKnownURL(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "host only",
+			input: "https://mcp.example.com",
+			want:  "https://mcp.example.com/.well-known/oauth-protected-resource",
+		},
+		{
+			name:  "with path",
+			input: "https://mcp.example.com/mcp",
+			want:  "https://mcp.example.com/.well-known/oauth-protected-resource/mcp",
+		},
+		{
+			name:  "with path and query",
+			input: "https://mcp.example.com/mcp?tenant=acme",
+			want:  "https://mcp.example.com/.well-known/oauth-protected-resource/mcp?tenant=acme",
+		},
+		{
+			name:  "trailing slash on path stripped before well-known insert",
+			input: "https://mcp.example.com/mcp/",
+			want:  "https://mcp.example.com/.well-known/oauth-protected-resource/mcp",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ProtectedResourceWellKnownURL(tt.input)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("ProtectedResourceWellKnownURL(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidatePRMResource(t *testing.T) {
+	tests := []struct {
+		name      string
+		prm       string
+		server    string
+		wantMatch bool
+	}{
+		{
+			name:      "matching canonical URIs",
+			prm:       "https://mcp.example.com/mcp",
+			server:    "HTTPS://mcp.example.com/mcp/",
+			wantMatch: true,
+		},
+		{
+			name:      "mismatched resource",
+			prm:       "https://other.example.com/mcp",
+			server:    "https://mcp.example.com/mcp",
+			wantMatch: false,
+		},
+		{
+			name:      "empty resource",
+			prm:       "",
+			server:    "https://mcp.example.com",
+			wantMatch: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidatePRMResource(tt.prm, tt.server)
+			if tt.wantMatch && err != nil {
+				t.Fatalf("expected match, got error: %v", err)
+			}
+			if !tt.wantMatch && err == nil {
+				t.Fatal("expected error")
+			}
+		})
+	}
+}

--- a/auth/www_authenticate.go
+++ b/auth/www_authenticate.go
@@ -4,35 +4,17 @@ import (
 	"strings"
 )
 
-// BearerChallenge represents a parsed WWW-Authenticate Bearer challenge,
-// as used by MCP servers per RFC 9728 §5.1.
+// BearerChallenge is a parsed WWW-Authenticate Bearer challenge (RFC 9728 §5.1).
 type BearerChallenge struct {
-	// ResourceMetadata is the value of the "resource_metadata" parameter,
-	// pointing at the Protected Resource Metadata document.
 	ResourceMetadata string
-
-	// Realm is the (optional) "realm" parameter.
-	Realm string
-
-	// Scope is the (optional) "scope" parameter.
-	Scope string
-
-	// Error and ErrorDescription are RFC 6750 error parameters, if present.
+	Realm            string
+	Scope            string
 	Error            string
 	ErrorDescription string
-
-	// Params holds any other parameters present in the challenge.
-	Params map[string]string
 }
 
-// ParseWWWAuthenticate parses a WWW-Authenticate header value looking for a
-// Bearer challenge. It tolerates multiple challenges in the same header and
-// returns the first Bearer one. If no Bearer challenge is found, the returned
-// challenge is the zero value and ok is false.
-//
-// The parser is intentionally lenient: it accepts both quoted and unquoted
-// parameter values and ignores parameters it cannot parse, rather than
-// failing the whole header.
+// ParseWWWAuthenticate returns the first Bearer challenge found in a
+// WWW-Authenticate header, tolerating multiple challenges in the same header.
 func ParseWWWAuthenticate(header string) (BearerChallenge, bool) {
 	header = strings.TrimSpace(header)
 	if header == "" {
@@ -65,18 +47,13 @@ func ParseWWWAuthenticate(header string) (BearerChallenge, bool) {
 	rest = strings.TrimSpace(rest)
 
 	params := parseAuthParams(rest)
-	if len(params) == 0 {
-		// A bare "Bearer" challenge is valid but uninteresting.
-		return BearerChallenge{Params: params}, true
-	}
-
-	ch := BearerChallenge{Params: params}
-	ch.ResourceMetadata = params["resource_metadata"]
-	ch.Realm = params["realm"]
-	ch.Scope = params["scope"]
-	ch.Error = params["error"]
-	ch.ErrorDescription = params["error_description"]
-	return ch, true
+	return BearerChallenge{
+		ResourceMetadata: params["resource_metadata"],
+		Realm:            params["realm"],
+		Scope:            params["scope"],
+		Error:            params["error"],
+		ErrorDescription: params["error_description"],
+	}, true
 }
 
 // parseAuthParams parses a comma-separated list of key=value or key="value"
@@ -121,7 +98,6 @@ func parseAuthParams(s string) map[string]string {
 		var value string
 		if i < len(s) && s[i] == '"' {
 			i++ // consume opening quote
-			valStart := i
 			var b strings.Builder
 			for i < len(s) {
 				c := s[i]
@@ -136,7 +112,6 @@ func parseAuthParams(s string) map[string]string {
 				b.WriteByte(c)
 				i++
 			}
-			_ = valStart
 			value = b.String()
 			if i < len(s) && s[i] == '"' {
 				i++ // consume closing quote

--- a/auth/www_authenticate.go
+++ b/auth/www_authenticate.go
@@ -23,37 +23,41 @@ func ParseWWWAuthenticate(header string) (BearerChallenge, bool) {
 
 	// A WWW-Authenticate header may contain multiple challenges separated by
 	// commas, but parameters are also comma-separated, which makes naive
-	// splitting unsafe. We instead scan for "Bearer" tokens and parse from
-	// there.
+	// splitting unsafe. Scan all "bearer" occurrences and accept the first
+	// one on a proper token boundary, so a non-boundary substring (e.g.
+	// "MyBearer") does not mask a real Bearer challenge later in the header.
 	const scheme = "bearer"
 	lower := strings.ToLower(header)
-	idx := strings.Index(lower, scheme)
-	if idx < 0 {
-		return BearerChallenge{}, false
-	}
-	// Require the match to be at a token boundary so we don't pick up e.g.
-	// "MyBearer".
-	if idx > 0 {
-		prev := header[idx-1]
-		if prev != ' ' && prev != ',' && prev != '\t' {
+
+	for offset := 0; offset < len(lower); {
+		idx := strings.Index(lower[offset:], scheme)
+		if idx < 0 {
 			return BearerChallenge{}, false
 		}
-	}
-	rest := header[idx+len(scheme):]
-	// The scheme name must be followed by whitespace or end-of-string.
-	if rest != "" && rest[0] != ' ' && rest[0] != '\t' {
-		return BearerChallenge{}, false
-	}
-	rest = strings.TrimSpace(rest)
+		pos := offset + idx
+		offset = pos + len(scheme)
 
-	params := parseAuthParams(rest)
-	return BearerChallenge{
-		ResourceMetadata: params["resource_metadata"],
-		Realm:            params["realm"],
-		Scope:            params["scope"],
-		Error:            params["error"],
-		ErrorDescription: params["error_description"],
-	}, true
+		if pos > 0 {
+			prev := header[pos-1]
+			if prev != ' ' && prev != ',' && prev != '\t' {
+				continue
+			}
+		}
+		rest := header[pos+len(scheme):]
+		if rest != "" && rest[0] != ' ' && rest[0] != '\t' && rest[0] != ',' {
+			continue
+		}
+
+		params := parseAuthParams(strings.TrimSpace(rest))
+		return BearerChallenge{
+			ResourceMetadata: params["resource_metadata"],
+			Realm:            params["realm"],
+			Scope:            params["scope"],
+			Error:            params["error"],
+			ErrorDescription: params["error_description"],
+		}, true
+	}
+	return BearerChallenge{}, false
 }
 
 // parseAuthParams parses a comma-separated list of key=value or key="value"

--- a/auth/www_authenticate.go
+++ b/auth/www_authenticate.go
@@ -63,13 +63,17 @@ func ParseWWWAuthenticate(header string) (BearerChallenge, bool) {
 // BestWWWAuthenticateHeader selects the most useful WWW-Authenticate field value
 // when a response carries multiple header lines (RFC 9110). Preference order:
 // Bearer challenge with resource_metadata, any Bearer challenge, then the first
-// non-empty line.
+// non-empty line (preserved for diagnostic logging even when the challenge is
+// not Bearer).
 func BestWWWAuthenticateHeader(headers []string) string {
-	var bearerFallback string
+	var firstLine, bearerFallback string
 	for _, h := range headers {
 		h = strings.TrimSpace(h)
 		if h == "" {
 			continue
+		}
+		if firstLine == "" {
+			firstLine = h
 		}
 		challenge, ok := ParseWWWAuthenticate(h)
 		if !ok {
@@ -82,7 +86,10 @@ func BestWWWAuthenticateHeader(headers []string) string {
 			bearerFallback = h
 		}
 	}
-	return bearerFallback
+	if bearerFallback != "" {
+		return bearerFallback
+	}
+	return firstLine
 }
 
 // ParseWWWAuthenticateHeaders parses Bearer challenges across multiple

--- a/auth/www_authenticate.go
+++ b/auth/www_authenticate.go
@@ -60,6 +60,41 @@ func ParseWWWAuthenticate(header string) (BearerChallenge, bool) {
 	return BearerChallenge{}, false
 }
 
+// BestWWWAuthenticateHeader selects the most useful WWW-Authenticate field value
+// when a response carries multiple header lines (RFC 9110). Preference order:
+// Bearer challenge with resource_metadata, any Bearer challenge, then the first
+// non-empty line.
+func BestWWWAuthenticateHeader(headers []string) string {
+	var bearerFallback string
+	for _, h := range headers {
+		h = strings.TrimSpace(h)
+		if h == "" {
+			continue
+		}
+		challenge, ok := ParseWWWAuthenticate(h)
+		if !ok {
+			continue
+		}
+		if challenge.ResourceMetadata != "" {
+			return h
+		}
+		if bearerFallback == "" {
+			bearerFallback = h
+		}
+	}
+	return bearerFallback
+}
+
+// ParseWWWAuthenticateHeaders parses Bearer challenges across multiple
+// WWW-Authenticate header field values.
+func ParseWWWAuthenticateHeaders(headers []string) (BearerChallenge, bool) {
+	h := BestWWWAuthenticateHeader(headers)
+	if h == "" {
+		return BearerChallenge{}, false
+	}
+	return ParseWWWAuthenticate(h)
+}
+
 // parseAuthParams parses a comma-separated list of key=value or key="value"
 // pairs. Values containing commas must be quoted. Unrecognised tokens
 // (e.g. another auth-scheme starting after a comma) terminate parsing.

--- a/auth/www_authenticate.go
+++ b/auth/www_authenticate.go
@@ -1,0 +1,155 @@
+package auth
+
+import (
+	"strings"
+)
+
+// BearerChallenge represents a parsed WWW-Authenticate Bearer challenge,
+// as used by MCP servers per RFC 9728 §5.1.
+type BearerChallenge struct {
+	// ResourceMetadata is the value of the "resource_metadata" parameter,
+	// pointing at the Protected Resource Metadata document.
+	ResourceMetadata string
+
+	// Realm is the (optional) "realm" parameter.
+	Realm string
+
+	// Scope is the (optional) "scope" parameter.
+	Scope string
+
+	// Error and ErrorDescription are RFC 6750 error parameters, if present.
+	Error            string
+	ErrorDescription string
+
+	// Params holds any other parameters present in the challenge.
+	Params map[string]string
+}
+
+// ParseWWWAuthenticate parses a WWW-Authenticate header value looking for a
+// Bearer challenge. It tolerates multiple challenges in the same header and
+// returns the first Bearer one. If no Bearer challenge is found, the returned
+// challenge is the zero value and ok is false.
+//
+// The parser is intentionally lenient: it accepts both quoted and unquoted
+// parameter values and ignores parameters it cannot parse, rather than
+// failing the whole header.
+func ParseWWWAuthenticate(header string) (BearerChallenge, bool) {
+	header = strings.TrimSpace(header)
+	if header == "" {
+		return BearerChallenge{}, false
+	}
+
+	// A WWW-Authenticate header may contain multiple challenges separated by
+	// commas, but parameters are also comma-separated, which makes naive
+	// splitting unsafe. We instead scan for "Bearer" tokens and parse from
+	// there.
+	const scheme = "bearer"
+	lower := strings.ToLower(header)
+	idx := strings.Index(lower, scheme)
+	if idx < 0 {
+		return BearerChallenge{}, false
+	}
+	// Require the match to be at a token boundary so we don't pick up e.g.
+	// "MyBearer".
+	if idx > 0 {
+		prev := header[idx-1]
+		if prev != ' ' && prev != ',' && prev != '\t' {
+			return BearerChallenge{}, false
+		}
+	}
+	rest := header[idx+len(scheme):]
+	// The scheme name must be followed by whitespace or end-of-string.
+	if rest != "" && rest[0] != ' ' && rest[0] != '\t' {
+		return BearerChallenge{}, false
+	}
+	rest = strings.TrimSpace(rest)
+
+	params := parseAuthParams(rest)
+	if len(params) == 0 {
+		// A bare "Bearer" challenge is valid but uninteresting.
+		return BearerChallenge{Params: params}, true
+	}
+
+	ch := BearerChallenge{Params: params}
+	ch.ResourceMetadata = params["resource_metadata"]
+	ch.Realm = params["realm"]
+	ch.Scope = params["scope"]
+	ch.Error = params["error"]
+	ch.ErrorDescription = params["error_description"]
+	return ch, true
+}
+
+// parseAuthParams parses a comma-separated list of key=value or key="value"
+// pairs. Values containing commas must be quoted. Unrecognised tokens
+// (e.g. another auth-scheme starting after a comma) terminate parsing.
+func parseAuthParams(s string) map[string]string {
+	params := make(map[string]string)
+	i := 0
+	for i < len(s) {
+		// Skip leading whitespace and commas.
+		for i < len(s) && (s[i] == ' ' || s[i] == '\t' || s[i] == ',') {
+			i++
+		}
+		if i >= len(s) {
+			break
+		}
+
+		// Read key up to '='.
+		keyStart := i
+		for i < len(s) && s[i] != '=' && s[i] != ',' && s[i] != ' ' && s[i] != '\t' {
+			i++
+		}
+		key := strings.ToLower(s[keyStart:i])
+		if key == "" {
+			return params
+		}
+		// Skip whitespace.
+		for i < len(s) && (s[i] == ' ' || s[i] == '\t') {
+			i++
+		}
+		if i >= len(s) || s[i] != '=' {
+			// A token without '=' likely marks the start of a new
+			// challenge (e.g. "Basic realm=..."); stop parsing.
+			return params
+		}
+		i++ // consume '='
+		for i < len(s) && (s[i] == ' ' || s[i] == '\t') {
+			i++
+		}
+
+		// Read value: quoted or unquoted.
+		var value string
+		if i < len(s) && s[i] == '"' {
+			i++ // consume opening quote
+			valStart := i
+			var b strings.Builder
+			for i < len(s) {
+				c := s[i]
+				if c == '\\' && i+1 < len(s) {
+					b.WriteByte(s[i+1])
+					i += 2
+					continue
+				}
+				if c == '"' {
+					break
+				}
+				b.WriteByte(c)
+				i++
+			}
+			_ = valStart
+			value = b.String()
+			if i < len(s) && s[i] == '"' {
+				i++ // consume closing quote
+			}
+		} else {
+			valStart := i
+			for i < len(s) && s[i] != ',' && s[i] != ' ' && s[i] != '\t' {
+				i++
+			}
+			value = s[valStart:i]
+		}
+
+		params[key] = value
+	}
+	return params
+}

--- a/auth/www_authenticate_test.go
+++ b/auth/www_authenticate_test.go
@@ -1,0 +1,105 @@
+package auth
+
+import "testing"
+
+func TestParseWWWAuthenticate(t *testing.T) {
+	tests := []struct {
+		name             string
+		header           string
+		wantOK           bool
+		wantResourceMeta string
+		wantRealm        string
+		wantScope        string
+		wantError        string
+	}{
+		{
+			name:             "spec example: resource_metadata only",
+			header:           `Bearer resource_metadata="https://mcp.example.com/.well-known/oauth-protected-resource"`,
+			wantOK:           true,
+			wantResourceMeta: "https://mcp.example.com/.well-known/oauth-protected-resource",
+		},
+		{
+			name:             "multiple params with realm and scope",
+			header:           `Bearer realm="mcp", scope="read write", resource_metadata="https://as.example.com/.well-known/oauth-protected-resource"`,
+			wantOK:           true,
+			wantResourceMeta: "https://as.example.com/.well-known/oauth-protected-resource",
+			wantRealm:        "mcp",
+			wantScope:        "read write",
+		},
+		{
+			name:      "unquoted values",
+			header:    `Bearer realm=mcp, scope=read`,
+			wantOK:    true,
+			wantRealm: "mcp",
+			wantScope: "read",
+		},
+		{
+			name:      "error parameter",
+			header:    `Bearer error="invalid_token", error_description="Token expired"`,
+			wantOK:    true,
+			wantError: "invalid_token",
+		},
+		{
+			name:             "case-insensitive scheme",
+			header:           `bearer resource_metadata="https://example.com/prm"`,
+			wantOK:           true,
+			wantResourceMeta: "https://example.com/prm",
+		},
+		{
+			name:   "bare Bearer challenge",
+			header: `Bearer`,
+			wantOK: true,
+		},
+		{
+			name:   "empty header",
+			header: ``,
+			wantOK: false,
+		},
+		{
+			name:   "no Bearer challenge",
+			header: `Basic realm="example"`,
+			wantOK: false,
+		},
+		{
+			name:             "Bearer preceded by another scheme",
+			header:           `Basic realm="x", Bearer resource_metadata="https://example.com/prm"`,
+			wantOK:           true,
+			wantResourceMeta: "https://example.com/prm",
+		},
+		{
+			name:      "quoted value with embedded escape",
+			header:    `Bearer realm="quote\"inside"`,
+			wantOK:    true,
+			wantRealm: `quote"inside`,
+		},
+		{
+			name:   "MyBearer should not match Bearer",
+			header: `MyBearer resource_metadata="https://example.com/prm"`,
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := ParseWWWAuthenticate(tt.header)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v (parsed: %+v)", ok, tt.wantOK, got)
+			}
+			if !ok {
+				return
+			}
+			if got.ResourceMetadata != tt.wantResourceMeta {
+				t.Errorf("ResourceMetadata = %q, want %q", got.ResourceMetadata, tt.wantResourceMeta)
+			}
+			if got.Realm != tt.wantRealm {
+				t.Errorf("Realm = %q, want %q", got.Realm, tt.wantRealm)
+			}
+			if got.Scope != tt.wantScope {
+				t.Errorf("Scope = %q, want %q", got.Scope, tt.wantScope)
+			}
+			if got.Error != tt.wantError {
+				t.Errorf("Error = %q, want %q", got.Error, tt.wantError)
+			}
+		})
+	}
+}

--- a/auth/www_authenticate_test.go
+++ b/auth/www_authenticate_test.go
@@ -145,6 +145,16 @@ func TestBestWWWAuthenticateHeader(t *testing.T) {
 			headers: nil,
 			want:    "",
 		},
+		{
+			name:    "no Bearer falls back to first non-empty line for diagnostics",
+			headers: []string{`Digest realm="corp"`, `Negotiate`},
+			want:    `Digest realm="corp"`,
+		},
+		{
+			name:    "blank lines are skipped when falling back",
+			headers: []string{"", `  `, `Digest realm="corp"`},
+			want:    `Digest realm="corp"`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/auth/www_authenticate_test.go
+++ b/auth/www_authenticate_test.go
@@ -115,3 +115,57 @@ func TestParseWWWAuthenticate(t *testing.T) {
 		})
 	}
 }
+
+func TestBestWWWAuthenticateHeader(t *testing.T) {
+	const bearerPRM = `Bearer resource_metadata="https://example.com/prm"`
+	const bearerBare = `Bearer realm="mcp"`
+
+	tests := []struct {
+		name    string
+		headers []string
+		want    string
+	}{
+		{
+			name:    "prefers Bearer with resource_metadata over earlier Digest line",
+			headers: []string{`Digest realm="corp"`, bearerPRM},
+			want:    bearerPRM,
+		},
+		{
+			name:    "skips non-Bearer lines",
+			headers: []string{`Negotiate`, bearerPRM},
+			want:    bearerPRM,
+		},
+		{
+			name:    "falls back to Bearer without resource_metadata",
+			headers: []string{`Digest realm="corp"`, bearerBare},
+			want:    bearerBare,
+		},
+		{
+			name:    "empty",
+			headers: nil,
+			want:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := BestWWWAuthenticateHeader(tt.headers); got != tt.want {
+				t.Errorf("BestWWWAuthenticateHeader() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseWWWAuthenticateHeaders(t *testing.T) {
+	headers := []string{
+		`Digest realm="corp"`,
+		`Bearer resource_metadata="https://example.com/prm"`,
+	}
+	challenge, ok := ParseWWWAuthenticateHeaders(headers)
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	if challenge.ResourceMetadata != "https://example.com/prm" {
+		t.Errorf("ResourceMetadata = %q", challenge.ResourceMetadata)
+	}
+}

--- a/auth/www_authenticate_test.go
+++ b/auth/www_authenticate_test.go
@@ -77,6 +77,18 @@ func TestParseWWWAuthenticate(t *testing.T) {
 			header: `MyBearer resource_metadata="https://example.com/prm"`,
 			wantOK: false,
 		},
+		{
+			name:             "non-boundary bearer earlier in header does not mask later Bearer",
+			header:           `MyBearer foo=bar, Bearer resource_metadata="https://example.com/prm"`,
+			wantOK:           true,
+			wantResourceMeta: "https://example.com/prm",
+		},
+		{
+			name:             "bearer substring inside a quoted realm before a real Bearer challenge",
+			header:           `Basic realm="Bearer-Realm", Bearer resource_metadata="https://example.com/prm"`,
+			wantOK:           true,
+			wantResourceMeta: "https://example.com/prm",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/httpclient/client.go
+++ b/internal/httpclient/client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	neturl "net/url"
 	"time"
 )
 
@@ -223,23 +224,15 @@ func (c *Client) PostForm(ctx context.Context, url string, formData map[string]s
 	}
 	headers["Content-Type"] = "application/x-www-form-urlencoded"
 
-	// Convert form data to URL-encoded string
-	values := make([]string, 0, len(formData))
+	values := make(neturl.Values, len(formData))
 	for key, value := range formData {
-		values = append(values, fmt.Sprintf("%s=%s", key, value))
-	}
-	body := ""
-	for i, v := range values {
-		if i > 0 {
-			body += "&"
-		}
-		body += v
+		values.Set(key, value)
 	}
 
 	return c.Do(ctx, &Request{
 		Method:  http.MethodPost,
 		URL:     url,
 		Headers: headers,
-		Body:    body,
+		Body:    values.Encode(),
 	})
 }

--- a/internal/httpclient/client_test.go
+++ b/internal/httpclient/client_test.go
@@ -160,6 +160,46 @@ func TestPostForm(t *testing.T) {
 	}
 }
 
+// TestPostFormEncodesSpecialCharacters guards against form-body corruption
+// when a value contains characters that are significant in
+// application/x-www-form-urlencoded (e.g. '&', '=', '+', ' ', or non-ASCII).
+// Regression case: an OAuth `resource` parameter carrying a query string
+// like `https://mcp.example.com/x?tenant=acme&debug=1` would otherwise be
+// split into multiple form fields.
+func TestPostFormEncodesSpecialCharacters(t *testing.T) {
+	const tricky = "https://mcp.example.com/x?tenant=acme&debug=1 path with spaces"
+
+	var (
+		gotResource string
+		gotOther    string
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm failed: %v", err)
+		}
+		gotResource = r.Form.Get("resource")
+		gotOther = r.Form.Get("other")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	resp, err := New(nil).PostForm(context.Background(), server.URL, map[string]string{
+		"resource": tricky,
+		"other":    "plain",
+	}, nil)
+	if err != nil {
+		t.Fatalf("PostForm failed: %v", err)
+	}
+	_ = resp.SafeClose()
+
+	if gotResource != tricky {
+		t.Errorf("resource decoded as %q, want %q", gotResource, tricky)
+	}
+	if gotOther != "plain" {
+		t.Errorf("other = %q, want %q", gotOther, "plain")
+	}
+}
+
 func TestErrorHandling(t *testing.T) {
 	// Test server that returns 404
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/proxy/auth_error.go
+++ b/proxy/auth_error.go
@@ -1,0 +1,26 @@
+package proxy
+
+import "fmt"
+
+// UnauthorizedError signals that the remote MCP server returned an HTTP 401
+// Unauthorized response. It carries the raw WWW-Authenticate header so the
+// caller can extract the Protected Resource Metadata URL per RFC 9728 §5.1,
+// as required by the MCP authorization specification:
+//
+//	"MCP clients MUST be able to parse WWW-Authenticate headers and respond
+//	 appropriately to HTTP 401 Unauthorized responses from the MCP server."
+type UnauthorizedError struct {
+	StatusCode      int
+	WWWAuthenticate string
+	Body            string
+}
+
+func (e *UnauthorizedError) Error() string {
+	if e == nil {
+		return "unauthorized"
+	}
+	if e.WWWAuthenticate != "" {
+		return fmt.Sprintf("server returned %d Unauthorized (WWW-Authenticate: %s)", e.StatusCode, e.WWWAuthenticate)
+	}
+	return fmt.Sprintf("server returned %d Unauthorized", e.StatusCode)
+}

--- a/proxy/auth_error.go
+++ b/proxy/auth_error.go
@@ -1,26 +1,41 @@
 package proxy
 
-import "fmt"
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+)
 
-// UnauthorizedError signals that the remote MCP server returned an HTTP 401
-// Unauthorized response. It carries the raw WWW-Authenticate header so the
-// caller can extract the Protected Resource Metadata URL per RFC 9728 §5.1,
-// as required by the MCP authorization specification:
-//
-//	"MCP clients MUST be able to parse WWW-Authenticate headers and respond
-//	 appropriately to HTTP 401 Unauthorized responses from the MCP server."
+// HeaderWWWAuthenticate is the response header name carrying the Bearer
+// challenge that points at the Protected Resource Metadata document
+// (RFC 9728 §5.1).
+const HeaderWWWAuthenticate = "WWW-Authenticate"
+
+// UnauthorizedError signals an HTTP 401 from the MCP server and carries the
+// WWW-Authenticate header so callers can locate the Protected Resource
+// Metadata document per RFC 9728 §5.1.
 type UnauthorizedError struct {
 	StatusCode      int
 	WWWAuthenticate string
-	Body            string
 }
 
 func (e *UnauthorizedError) Error() string {
-	if e == nil {
-		return "unauthorized"
-	}
 	if e.WWWAuthenticate != "" {
 		return fmt.Sprintf("server returned %d Unauthorized (WWW-Authenticate: %s)", e.StatusCode, e.WWWAuthenticate)
 	}
 	return fmt.Sprintf("server returned %d Unauthorized", e.StatusCode)
+}
+
+// unauthorizedFromResponse drains and closes the response body, then returns
+// an UnauthorizedError carrying the WWW-Authenticate header.
+func unauthorizedFromResponse(resp *http.Response) *UnauthorizedError {
+	_, _ = io.Copy(io.Discard, resp.Body)
+	if err := resp.Body.Close(); err != nil {
+		log.Printf("Warning: failed to close response body: %v", err)
+	}
+	return &UnauthorizedError{
+		StatusCode:      resp.StatusCode,
+		WWWAuthenticate: resp.Header.Get(HeaderWWWAuthenticate),
+	}
 }

--- a/proxy/auth_error.go
+++ b/proxy/auth_error.go
@@ -5,6 +5,8 @@ import (
 	"io"
 	"log"
 	"net/http"
+
+	"github.com/naotama2002/mcp-remote-go/auth"
 )
 
 // HeaderWWWAuthenticate is the response header name carrying the Bearer
@@ -36,6 +38,6 @@ func unauthorizedFromResponse(resp *http.Response) *UnauthorizedError {
 	}
 	return &UnauthorizedError{
 		StatusCode:      resp.StatusCode,
-		WWWAuthenticate: resp.Header.Get(HeaderWWWAuthenticate),
+		WWWAuthenticate: auth.BestWWWAuthenticateHeader(resp.Header.Values(HeaderWWWAuthenticate)),
 	}
 }

--- a/proxy/eventsource.go
+++ b/proxy/eventsource.go
@@ -66,6 +66,19 @@ func (es *EventSource) Connect() error {
 	}
 
 	// Check response code
+	if resp.StatusCode == http.StatusUnauthorized {
+		body, _ := io.ReadAll(resp.Body)
+		wwwAuth := resp.Header.Get("WWW-Authenticate")
+		if err := resp.Body.Close(); err != nil {
+			log.Printf("Warning: failed to close response body: %v", err)
+		}
+		return &UnauthorizedError{
+			StatusCode:      resp.StatusCode,
+			WWWAuthenticate: wwwAuth,
+			Body:            string(body),
+		}
+	}
+
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
 		if err := resp.Body.Close(); err != nil {

--- a/proxy/eventsource.go
+++ b/proxy/eventsource.go
@@ -67,16 +67,7 @@ func (es *EventSource) Connect() error {
 
 	// Check response code
 	if resp.StatusCode == http.StatusUnauthorized {
-		body, _ := io.ReadAll(resp.Body)
-		wwwAuth := resp.Header.Get("WWW-Authenticate")
-		if err := resp.Body.Close(); err != nil {
-			log.Printf("Warning: failed to close response body: %v", err)
-		}
-		return &UnauthorizedError{
-			StatusCode:      resp.StatusCode,
-			WWWAuthenticate: wwwAuth,
-			Body:            string(body),
-		}
+		return unauthorizedFromResponse(resp)
 	}
 
 	if resp.StatusCode != http.StatusOK {

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -208,7 +208,7 @@ func (p *Proxy) negotiateTransport() error {
 	}
 
 	body, _ := io.ReadAll(resp.Body)
-	wwwAuth := resp.Header.Get(HeaderWWWAuthenticate)
+	wwwAuth := auth.BestWWWAuthenticateHeader(resp.Header.Values(HeaderWWWAuthenticate))
 	if closeErr := resp.Body.Close(); closeErr != nil {
 		log.Printf("Warning: failed to close probe response body: %v", closeErr)
 	}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -208,7 +208,7 @@ func (p *Proxy) negotiateTransport() error {
 	}
 
 	body, _ := io.ReadAll(resp.Body)
-	wwwAuth := resp.Header.Get("WWW-Authenticate")
+	wwwAuth := resp.Header.Get(HeaderWWWAuthenticate)
 	if closeErr := resp.Body.Close(); closeErr != nil {
 		log.Printf("Warning: failed to close probe response body: %v", closeErr)
 	}
@@ -299,10 +299,9 @@ func openBrowser(rawURL string) error {
 	return browser.OpenURL(rawURL)
 }
 
-// handleAuthentication handles the OAuth flow. The optional wwwAuthenticate
-// argument is the value of the WWW-Authenticate header from the triggering
-// 401 response; when present, the resource_metadata parameter (RFC 9728 §5.1)
-// is extracted and used to locate the Protected Resource Metadata document.
+// handleAuthentication runs the OAuth flow. When the triggering 401 carried a
+// WWW-Authenticate Bearer challenge, its resource_metadata URL (RFC 9728 §5.1)
+// is forwarded to discovery.
 func (p *Proxy) handleAuthentication(wwwAuthenticate string) error {
 	var initOpts []auth.InitOption
 	if wwwAuthenticate != "" {

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -166,9 +166,10 @@ func (p *Proxy) connectToServer() error {
 
 	err := t.Connect(p.ctx)
 	if err != nil {
-		if strings.Contains(err.Error(), "401") || strings.Contains(err.Error(), "Unauthorized") {
+		var unauth *UnauthorizedError
+		if errors.As(err, &unauth) {
 			log.Println("Authentication required")
-			return p.handleAuthentication()
+			return p.handleAuthentication(unauth.WWWAuthenticate)
 		}
 		return fmt.Errorf("failed to connect: %w", err)
 	}
@@ -207,6 +208,7 @@ func (p *Proxy) negotiateTransport() error {
 	}
 
 	body, _ := io.ReadAll(resp.Body)
+	wwwAuth := resp.Header.Get("WWW-Authenticate")
 	if closeErr := resp.Body.Close(); closeErr != nil {
 		log.Printf("Warning: failed to close probe response body: %v", closeErr)
 	}
@@ -222,7 +224,7 @@ func (p *Proxy) negotiateTransport() error {
 
 	case resp.StatusCode == http.StatusUnauthorized:
 		log.Println("Authentication required")
-		return p.handleAuthentication()
+		return p.handleAuthentication(wwwAuth)
 
 	case resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusMethodNotAllowed:
 		// Server does not support Streamable HTTP, fall back to SSE
@@ -249,9 +251,10 @@ func (p *Proxy) connectWithMode(mode TransportMode) error {
 
 	err := t.Connect(p.ctx)
 	if err != nil {
-		if strings.Contains(err.Error(), "401") || strings.Contains(err.Error(), "Unauthorized") {
+		var unauth *UnauthorizedError
+		if errors.As(err, &unauth) {
 			log.Println("Authentication required")
-			return p.handleAuthentication()
+			return p.handleAuthentication(unauth.WWWAuthenticate)
 		}
 		return fmt.Errorf("failed to connect with %s transport: %w", mode, err)
 	}
@@ -296,9 +299,20 @@ func openBrowser(rawURL string) error {
 	return browser.OpenURL(rawURL)
 }
 
-// handleAuthentication handles the OAuth flow
-func (p *Proxy) handleAuthentication() error {
-	authURL, err := p.authCoord.InitializeAuth(p.serverURL)
+// handleAuthentication handles the OAuth flow. The optional wwwAuthenticate
+// argument is the value of the WWW-Authenticate header from the triggering
+// 401 response; when present, the resource_metadata parameter (RFC 9728 §5.1)
+// is extracted and used to locate the Protected Resource Metadata document.
+func (p *Proxy) handleAuthentication(wwwAuthenticate string) error {
+	var initOpts []auth.InitOption
+	if wwwAuthenticate != "" {
+		if challenge, ok := auth.ParseWWWAuthenticate(wwwAuthenticate); ok && challenge.ResourceMetadata != "" {
+			log.Printf("Using resource_metadata URL from WWW-Authenticate: %s", challenge.ResourceMetadata)
+			initOpts = append(initOpts, auth.WithResourceMetadataURL(challenge.ResourceMetadata))
+		}
+	}
+
+	authURL, err := p.authCoord.InitializeAuth(p.serverURL, initOpts...)
 	if err != nil {
 		return fmt.Errorf("failed to initialize auth: %w", err)
 	}
@@ -420,9 +434,10 @@ func (p *Proxy) handleServerError(err error) {
 		return
 	}
 
-	if strings.Contains(err.Error(), "401") || strings.Contains(err.Error(), "Unauthorized") {
+	var unauth *UnauthorizedError
+	if errors.As(err, &unauth) {
 		log.Println("Authentication error, trying to re-authenticate...")
-		if err := p.handleAuthentication(); err != nil {
+		if err := p.handleAuthentication(unauth.WWWAuthenticate); err != nil {
 			log.Printf("Re-authentication failed: %v", err)
 			p.Shutdown()
 		}

--- a/proxy/transport_sse.go
+++ b/proxy/transport_sse.go
@@ -120,6 +120,15 @@ func (t *SSETransport) Send(ctx context.Context, message []byte) error {
 		}
 	}()
 
+	if resp.StatusCode == http.StatusUnauthorized {
+		body, _ := io.ReadAll(resp.Body)
+		return &UnauthorizedError{
+			StatusCode:      resp.StatusCode,
+			WWWAuthenticate: resp.Header.Get("WWW-Authenticate"),
+			Body:            string(body),
+		}
+	}
+
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
 		body, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("server returned error status: %d - %s", resp.StatusCode, string(body))

--- a/proxy/transport_sse.go
+++ b/proxy/transport_sse.go
@@ -121,12 +121,7 @@ func (t *SSETransport) Send(ctx context.Context, message []byte) error {
 	}()
 
 	if resp.StatusCode == http.StatusUnauthorized {
-		body, _ := io.ReadAll(resp.Body)
-		return &UnauthorizedError{
-			StatusCode:      resp.StatusCode,
-			WWWAuthenticate: resp.Header.Get("WWW-Authenticate"),
-			Body:            string(body),
-		}
+		return unauthorizedFromResponse(resp)
 	}
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {

--- a/proxy/transport_sse.go
+++ b/proxy/transport_sse.go
@@ -114,15 +114,18 @@ func (t *SSETransport) Send(ctx context.Context, message []byte) error {
 	if err != nil {
 		return fmt.Errorf("POST request failed: %w", err)
 	}
+
+	// unauthorizedFromResponse takes ownership of the body, so this check
+	// must happen before the deferred Close to avoid a double-close.
+	if resp.StatusCode == http.StatusUnauthorized {
+		return unauthorizedFromResponse(resp)
+	}
+
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
 			log.Printf("Warning: failed to close response body: %v", err)
 		}
 	}()
-
-	if resp.StatusCode == http.StatusUnauthorized {
-		return unauthorizedFromResponse(resp)
-	}
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
 		body, _ := io.ReadAll(resp.Body)

--- a/proxy/transport_streamable.go
+++ b/proxy/transport_streamable.go
@@ -94,6 +94,19 @@ func (t *StreamableHTTPTransport) Send(ctx context.Context, message []byte) erro
 
 	contentType := resp.Header.Get("Content-Type")
 
+	if resp.StatusCode == http.StatusUnauthorized {
+		body, _ := io.ReadAll(resp.Body)
+		wwwAuth := resp.Header.Get("WWW-Authenticate")
+		if err := resp.Body.Close(); err != nil {
+			log.Printf("Warning: failed to close response body: %v", err)
+		}
+		return &UnauthorizedError{
+			StatusCode:      resp.StatusCode,
+			WWWAuthenticate: wwwAuth,
+			Body:            string(body),
+		}
+	}
+
 	switch {
 	case resp.StatusCode == http.StatusAccepted:
 		// Server accepted but will send response via notification stream
@@ -269,6 +282,19 @@ func (t *StreamableHTTPTransport) openNotificationStream(ctx context.Context) er
 		log.Println("Server does not support GET notification stream (405), notifications will arrive via POST responses")
 		// Return a sentinel error to stop the reconnection loop
 		return errNotificationStreamNotSupported
+	}
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		body, _ := io.ReadAll(resp.Body)
+		wwwAuth := resp.Header.Get("WWW-Authenticate")
+		if err := resp.Body.Close(); err != nil {
+			log.Printf("Warning: failed to close response body: %v", err)
+		}
+		return &UnauthorizedError{
+			StatusCode:      resp.StatusCode,
+			WWWAuthenticate: wwwAuth,
+			Body:            string(body),
+		}
 	}
 
 	if resp.StatusCode != http.StatusOK {

--- a/proxy/transport_streamable.go
+++ b/proxy/transport_streamable.go
@@ -95,16 +95,7 @@ func (t *StreamableHTTPTransport) Send(ctx context.Context, message []byte) erro
 	contentType := resp.Header.Get("Content-Type")
 
 	if resp.StatusCode == http.StatusUnauthorized {
-		body, _ := io.ReadAll(resp.Body)
-		wwwAuth := resp.Header.Get("WWW-Authenticate")
-		if err := resp.Body.Close(); err != nil {
-			log.Printf("Warning: failed to close response body: %v", err)
-		}
-		return &UnauthorizedError{
-			StatusCode:      resp.StatusCode,
-			WWWAuthenticate: wwwAuth,
-			Body:            string(body),
-		}
+		return unauthorizedFromResponse(resp)
 	}
 
 	switch {
@@ -285,16 +276,7 @@ func (t *StreamableHTTPTransport) openNotificationStream(ctx context.Context) er
 	}
 
 	if resp.StatusCode == http.StatusUnauthorized {
-		body, _ := io.ReadAll(resp.Body)
-		wwwAuth := resp.Header.Get("WWW-Authenticate")
-		if err := resp.Body.Close(); err != nil {
-			log.Printf("Warning: failed to close response body: %v", err)
-		}
-		return &UnauthorizedError{
-			StatusCode:      resp.StatusCode,
-			WWWAuthenticate: wwwAuth,
-			Body:            string(body),
-		}
+		return unauthorizedFromResponse(resp)
 	}
 
 	if resp.StatusCode != http.StatusOK {

--- a/proxy/transport_streamable.go
+++ b/proxy/transport_streamable.go
@@ -234,6 +234,13 @@ func (t *StreamableHTTPTransport) startNotificationStream(ctx context.Context) {
 				if errors.Is(err, errNotificationStreamNotSupported) {
 					return
 				}
+				var unauth *UnauthorizedError
+				if errors.As(err, &unauth) {
+					if t.onError != nil {
+						t.onError(unauth)
+					}
+					return
+				}
 				log.Printf("Notification stream error: %v, reconnecting...", err)
 				select {
 				case <-notifyCtx.Done():

--- a/proxy/unauthorized_test.go
+++ b/proxy/unauthorized_test.go
@@ -1,10 +1,13 @@
 package proxy
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -72,6 +75,37 @@ func TestSSEConnectReturnsUnauthorizedError(t *testing.T) {
 	}
 	if unauth.WWWAuthenticate != wwwAuth {
 		t.Errorf("WWWAuthenticate = %q, want %q", unauth.WWWAuthenticate, wwwAuth)
+	}
+}
+
+// TestSSESendUnauthorizedDoesNotDoubleCloseBody guards against the
+// `unauthorizedFromResponse` helper closing the response body while a deferred
+// Close in the caller still tries to close it again — that produced a noisy
+// "failed to close response body" log line on every 401.
+func TestSSESendUnauthorizedDoesNotDoubleCloseBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("WWW-Authenticate", `Bearer resource_metadata="https://example.com/prm"`)
+		http.Error(w, "unauthorised", http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	var buf bytes.Buffer
+	origOutput := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(origOutput)
+
+	transport := NewSSETransport(SSETransportConfig{
+		ServerURL: srv.URL,
+		Client:    srv.Client(),
+	})
+	transport.setCommandEndpoint(srv.URL)
+
+	if err := transport.Send(context.Background(), []byte(`{"jsonrpc":"2.0","id":1,"method":"ping"}`)); err == nil {
+		t.Fatal("expected 401 error from Send, got nil")
+	}
+
+	if strings.Contains(buf.String(), "failed to close response body") {
+		t.Errorf("unexpected double-close warning in log output:\n%s", buf.String())
 	}
 }
 

--- a/proxy/unauthorized_test.go
+++ b/proxy/unauthorized_test.go
@@ -8,7 +8,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 )
 
 // TestStreamableHTTPSendReturnsUnauthorizedError verifies that a 401 response
@@ -39,6 +41,95 @@ func TestStreamableHTTPSendReturnsUnauthorizedError(t *testing.T) {
 	}
 	if unauth.StatusCode != http.StatusUnauthorized {
 		t.Errorf("StatusCode = %d, want %d", unauth.StatusCode, http.StatusUnauthorized)
+	}
+	if unauth.WWWAuthenticate != wwwAuth {
+		t.Errorf("WWWAuthenticate = %q, want %q", unauth.WWWAuthenticate, wwwAuth)
+	}
+}
+
+// TestUnauthorizedErrorUsesBearerFromSecondWWWAuthenticateHeader verifies that
+// when the server sends multiple WWW-Authenticate header lines, the Bearer
+// challenge (especially with resource_metadata) is selected instead of only
+// reading the first line via Header.Get.
+func TestUnauthorizedErrorUsesBearerFromSecondWWWAuthenticateHeader(t *testing.T) {
+	const digestLine = `Digest realm="corp"`
+	const bearerLine = `Bearer resource_metadata="https://example.com/prm"`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("WWW-Authenticate", digestLine)
+		w.Header().Add("WWW-Authenticate", bearerLine)
+		http.Error(w, "unauthorised", http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	transport := NewStreamableHTTPTransport(StreamableHTTPTransportConfig{
+		Endpoint: srv.URL,
+		Client:   srv.Client(),
+	})
+
+	err := transport.Send(context.Background(), []byte(`{"jsonrpc":"2.0","method":"ping","id":1}`))
+	if err == nil {
+		t.Fatal("expected error from Send, got nil")
+	}
+
+	var unauth *UnauthorizedError
+	if !errors.As(err, &unauth) {
+		t.Fatalf("expected *UnauthorizedError, got %T: %v", err, err)
+	}
+	if unauth.WWWAuthenticate != bearerLine {
+		t.Errorf("WWWAuthenticate = %q, want %q", unauth.WWWAuthenticate, bearerLine)
+	}
+}
+
+// TestStreamableHTTPNotificationStreamUnauthorizedCallsOnError verifies that a
+// 401 on the background GET notification stream surfaces via SetOnError so the
+// proxy can re-authenticate instead of retrying indefinitely.
+func TestStreamableHTTPNotificationStreamUnauthorizedCallsOnError(t *testing.T) {
+	const wwwAuth = `Bearer resource_metadata="https://example.com/prm"`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.Header().Set("WWW-Authenticate", wwwAuth)
+		http.Error(w, "unauthorised", http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	var (
+		onErrOnce sync.Once
+		onErr     error
+	)
+	done := make(chan struct{})
+
+	transport := NewStreamableHTTPTransport(StreamableHTTPTransportConfig{
+		Endpoint: srv.URL,
+		Client:   srv.Client(),
+	})
+	transport.SetOnError(func(err error) {
+		onErrOnce.Do(func() {
+			onErr = err
+			close(done)
+		})
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := transport.Connect(ctx); err != nil {
+		t.Fatalf("Connect failed: %v", err)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for onError callback")
+	}
+
+	var unauth *UnauthorizedError
+	if !errors.As(onErr, &unauth) {
+		t.Fatalf("expected *UnauthorizedError, got %T: %v", onErr, onErr)
 	}
 	if unauth.WWWAuthenticate != wwwAuth {
 		t.Errorf("WWWAuthenticate = %q, want %q", unauth.WWWAuthenticate, wwwAuth)

--- a/proxy/unauthorized_test.go
+++ b/proxy/unauthorized_test.go
@@ -1,0 +1,110 @@
+package proxy
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestStreamableHTTPSendReturnsUnauthorizedError verifies that a 401 response
+// surfaces an *UnauthorizedError carrying the WWW-Authenticate header, instead
+// of being lost in a freeform error string.
+func TestStreamableHTTPSendReturnsUnauthorizedError(t *testing.T) {
+	const wwwAuth = `Bearer resource_metadata="https://as.example.com/.well-known/oauth-protected-resource"`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("WWW-Authenticate", wwwAuth)
+		http.Error(w, "unauthorised", http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	transport := NewStreamableHTTPTransport(StreamableHTTPTransportConfig{
+		Endpoint: srv.URL,
+		Client:   srv.Client(),
+	})
+
+	err := transport.Send(context.Background(), []byte(`{"jsonrpc":"2.0","method":"ping","id":1}`))
+	if err == nil {
+		t.Fatal("expected error from Send, got nil")
+	}
+
+	var unauth *UnauthorizedError
+	if !errors.As(err, &unauth) {
+		t.Fatalf("expected *UnauthorizedError, got %T: %v", err, err)
+	}
+	if unauth.StatusCode != http.StatusUnauthorized {
+		t.Errorf("StatusCode = %d, want %d", unauth.StatusCode, http.StatusUnauthorized)
+	}
+	if unauth.WWWAuthenticate != wwwAuth {
+		t.Errorf("WWWAuthenticate = %q, want %q", unauth.WWWAuthenticate, wwwAuth)
+	}
+}
+
+// TestSSEConnectReturnsUnauthorizedError verifies the SSE transport surfaces
+// 401 with WWW-Authenticate during Connect (the GET to the event stream).
+func TestSSEConnectReturnsUnauthorizedError(t *testing.T) {
+	const wwwAuth = `Bearer resource_metadata="https://example.com/prm", realm="mcp"`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("WWW-Authenticate", wwwAuth)
+		http.Error(w, "unauthorised", http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	transport := NewSSETransport(SSETransportConfig{
+		ServerURL: srv.URL,
+		Client:    srv.Client(),
+	})
+
+	err := transport.Connect(context.Background())
+	if err == nil {
+		t.Fatal("expected error from Connect, got nil")
+	}
+
+	var unauth *UnauthorizedError
+	if !errors.As(err, &unauth) {
+		t.Fatalf("expected *UnauthorizedError, got %T: %v", err, err)
+	}
+	if unauth.StatusCode != http.StatusUnauthorized {
+		t.Errorf("StatusCode = %d, want %d", unauth.StatusCode, http.StatusUnauthorized)
+	}
+	if unauth.WWWAuthenticate != wwwAuth {
+		t.Errorf("WWWAuthenticate = %q, want %q", unauth.WWWAuthenticate, wwwAuth)
+	}
+}
+
+// TestSSESendReturnsUnauthorizedError verifies the SSE transport surfaces 401
+// on the POST command endpoint.
+func TestSSESendReturnsUnauthorizedError(t *testing.T) {
+	const wwwAuth = `Bearer resource_metadata="https://example.com/prm"`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("WWW-Authenticate", wwwAuth)
+		http.Error(w, "unauthorised", http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	transport := NewSSETransport(SSETransportConfig{
+		ServerURL: srv.URL,
+		Client:    srv.Client(),
+	})
+	// Pretend the SSE handshake already happened by setting an explicit
+	// command endpoint; Send() short-circuits the "not connected" check
+	// when this is set.
+	transport.setCommandEndpoint(srv.URL)
+
+	err := transport.Send(context.Background(), []byte(`{"jsonrpc":"2.0","id":1,"method":"ping"}`))
+	if err == nil {
+		t.Fatal("expected error from Send, got nil")
+	}
+
+	var unauth *UnauthorizedError
+	if !errors.As(err, &unauth) {
+		t.Fatalf("expected *UnauthorizedError, got %T: %v", err, err)
+	}
+	if unauth.WWWAuthenticate != wwwAuth {
+		t.Errorf("WWWAuthenticate = %q, want %q", unauth.WWWAuthenticate, wwwAuth)
+	}
+}


### PR DESCRIPTION
## Summary

Bring the proxy into compliance with two **MUST** requirements of the MCP authorization spec ([2025-06-18](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization)) that were not being met:

1. **RFC 8707 Resource Indicator** — the `resource` parameter is now sent in both the authorization request and the token exchange, carrying the canonical URI of the MCP server. The spec states this MUST be sent *regardless of whether the AS supports it*.
2. **RFC 9728 §5.1 WWW-Authenticate parsing** — on a 401 response the proxy now parses the `WWW-Authenticate` Bearer challenge to extract the `resource_metadata` URL and uses it for Protected Resource Metadata discovery, instead of re-deriving one from the server host.

## What changed

### `auth/`
- `CanonicalResourceURI()` — lowercases scheme/host, strips trailing slash, rejects fragments per the spec's canonical URI rules.
- `ParseWWWAuthenticate()` — Bearer challenge parser (resource_metadata, realm, scope, error).
- `Coordinator.InitializeAuth` gains a `WithResourceMetadataURL(...)` option; the URL is threaded down to a new `NewProtectedResourceDiscoveryFromURL` strategy that fetches the supplied URL verbatim. When the explicit URL is supplied, the host-derived `.well-known/oauth-protected-resource` strategy is skipped (RFC 9728 §5.1 makes the WWW-Authenticate URL authoritative).
- Authorization URL and token POST now include the canonical `resource` parameter.

### `proxy/`
- New `UnauthorizedError` type carries `StatusCode` + raw `WWW-Authenticate`, plus a `unauthorizedFromResponse(*http.Response)` helper that all 401 sites share.
- Both SSE and Streamable HTTP transports (including the auto-negotiation probe) return `*UnauthorizedError` on 401 instead of a string-matched error. `proxy.go` consumes it via `errors.As` and forwards the header to the auth coordinator.

## Test plan

- [x] `go test ./...` — all packages pass
- [x] `go vet ./...` — clean
- [x] `make lint` — clean

New tests:
- `TestCanonicalResourceURI` (12 cases incl. lowercase, trailing slash, fragment rejection)
- `TestParseWWWAuthenticate` (11 cases incl. quoted/unquoted, escapes, multi-scheme headers)
- `TestResourceParameterSentInAuthAndTokenRequests` — verifies `resource` lands in both the auth URL and the token POST form
- `TestResourceParameterRejectsInvalidServerURL`
- `TestInitializeAuthUsesResourceMetadataURL` — verifies the WWW-Authenticate-supplied PRM URL is fetched (and the host-derived `.well-known` path is *not* hit)
- `TestStreamableHTTPSendReturnsUnauthorizedError`
- `TestSSEConnectReturnsUnauthorizedError`
- `TestSSESendReturnsUnauthorizedError`

Not covered: the small glue in `proxy.handleAuthentication` (UnauthorizedError → ParseWWWAuthenticate → WithResourceMetadataURL) is exercised piecewise via the unit tests above; a full end-to-end test would require making `openBrowser` swappable. Happy to add that as a follow-up if desired.

## Spec references
- MCP authorization §Authorization Server Discovery — "MCP clients **MUST** be able to parse `WWW-Authenticate` headers and respond appropriately to `HTTP 401 Unauthorized` responses"
- MCP authorization §Resource Parameter Implementation — "MCP clients **MUST** implement Resource Indicators for OAuth 2.0 … **MUST** be included in both authorization requests and token requests … regardless of whether authorization servers support it"