### PR TITLE
chore: fix pre-existing lint and gofmt drift

### DIFF
--- a/proxy/e2e_test.go
+++ b/proxy/e2e_test.go
@@ -52,8 +52,8 @@ func TestE2EStreamableHTTPAutoNegotiation(t *testing.T) {
 		"method":  "initialize",
 		"params": map[string]interface{}{
 			"protocolVersion": MCPProtocolVersion,
-			"capabilities":   map[string]interface{}{},
-			"clientInfo":     map[string]string{"name": "test-client", "version": "1.0.0"},
+			"capabilities":    map[string]interface{}{},
+			"clientInfo":      map[string]string{"name": "test-client", "version": "1.0.0"},
 		},
 	})
 
@@ -149,8 +149,8 @@ func TestE2EStreamableHTTPProbeIsolation(t *testing.T) {
 					"id":      msg["id"],
 					"result": map[string]interface{}{
 						"protocolVersion": MCPProtocolVersion,
-						"capabilities":   map[string]interface{}{},
-						"serverInfo":     map[string]string{"name": "test", "version": "1.0.0"},
+						"capabilities":    map[string]interface{}{},
+						"serverInfo":      map[string]string{"name": "test", "version": "1.0.0"},
 					},
 				})
 			default:
@@ -192,7 +192,7 @@ func TestE2EStreamableHTTPProbeIsolation(t *testing.T) {
 		"method":  "initialize",
 		"params": map[string]interface{}{
 			"protocolVersion": MCPProtocolVersion,
-			"capabilities":   map[string]interface{}{},
+			"capabilities":    map[string]interface{}{},
 		},
 	})
 
@@ -239,8 +239,8 @@ func TestE2ESSEFallbackPipeline(t *testing.T) {
 					"id":      msg["id"],
 					"result": map[string]interface{}{
 						"protocolVersion": "2024-11-05",
-						"capabilities":   map[string]interface{}{},
-						"serverInfo":     map[string]string{"name": "sse-server", "version": "1.0.0"},
+						"capabilities":    map[string]interface{}{},
+						"serverInfo":      map[string]string{"name": "sse-server", "version": "1.0.0"},
 					},
 				}
 			case "tools/list":
@@ -316,7 +316,7 @@ func TestE2ESSEFallbackPipeline(t *testing.T) {
 		"method":  "initialize",
 		"params": map[string]interface{}{
 			"protocolVersion": "2024-11-05",
-			"capabilities":   map[string]interface{}{},
+			"capabilities":    map[string]interface{}{},
 		},
 	})
 

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -23,9 +23,9 @@ import (
 type TransportMode string
 
 const (
-	TransportModeAuto          TransportMode = "auto"
+	TransportModeAuto           TransportMode = "auto"
 	TransportModeStreamableHTTP TransportMode = "streamable-http"
-	TransportModeSSE           TransportMode = "sse"
+	TransportModeSSE            TransportMode = "sse"
 )
 
 // Proxy handles the bidirectional communication between stdio (MCP client) and the remote server

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -159,6 +159,7 @@ func TestBuildHTTPClient_NoProxy(t *testing.T) {
 	}
 	if client == nil {
 		t.Fatal("Client should not be nil")
+		return
 	}
 	if client.Transport != nil {
 		t.Error("Transport should be nil (default) when no proxy is set")
@@ -172,6 +173,7 @@ func TestBuildHTTPClient_WithProxy(t *testing.T) {
 	}
 	if client == nil {
 		t.Fatal("Client should not be nil")
+		return
 	}
 	if client.Transport == nil {
 		t.Fatal("Transport should not be nil when proxy is set")

--- a/proxy/transport_streamable_test.go
+++ b/proxy/transport_streamable_test.go
@@ -510,7 +510,7 @@ func TestStreamableHTTPTransportE2E(t *testing.T) {
 					"id":      msg["id"],
 					"result": map[string]interface{}{
 						"protocolVersion": MCPProtocolVersion,
-						"capabilities":   map[string]interface{}{},
+						"capabilities":    map[string]interface{}{},
 						"serverInfo": map[string]string{
 							"name":    "test-server",
 							"version": "1.0.0",


### PR DESCRIPTION
## Summary

Two unrelated drive-by fixes that were originally bundled in #65; split out per request.

- **`proxy/proxy_test.go`** — `make lint` was failing on `main` because staticcheck's SA5011 doesn't recognise `t.Fatal` as terminating, so it flagged the subsequent field access (`client.Transport`) as a possible nil deref. Adding an explicit `return` after the `t.Fatal` calls satisfies the analysis without changing runtime behavior.
- **`proxy/e2e_test.go`, `proxy/transport_streamable_test.go`, `proxy/proxy.go`** — pure `gofmt` whitespace realignment for column drift in pre-existing map literals and a const block. No semantic changes.

## Test plan

- [x] `make lint` — 0 issues (previously: 4 SA5011 warnings)
- [x] `make check` (fmt + vet + lint) — clean
- [x] `go test ./...` — passes

## Why split

These changes are independent of the MCP-spec compliance work in #65. Splitting keeps each PR's diff focused on a single concern.