### PR TITLE
feat: clarify Authorization Header field and add Custom Headers (MCP_HEADERS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ The easiest way to use with Claude Desktop is via the `.mcpb` extension. After i
 | Allow HTTP | Allow insecure HTTP connections | `false` |
 | HTTP/HTTPS Proxy | Proxy server URL (e.g. `http://proxy:8080`) | — |
 | Authorization Header Value | **Value portion only** — do NOT prepend `Authorization:`. Examples: `Bearer eyJhbGc...`, `Basic dXNlcjpwYXNz` | — |
-| Custom Headers | Additional headers, one per line as `Name: Value`. Use this for `X-API-Key`, tenant IDs, etc. Authorization goes in the field above. | — |
+| Custom Headers | Additional headers as `Name: Value`. Because Claude Desktop's text field is single-line, separate multiple headers with the literal two-character sequence `\n` (e.g. `X-API-Key: secret\nX-Tenant: acme`). Use this for `X-API-Key`, tenant IDs, etc.; Authorization goes in the field above. | — |
 
 #### Format notes
 
@@ -205,7 +205,22 @@ docker run --rm -it \
   ghcr.io/naotama2002/mcp-remote-go:latest https://remote.mcp.server/mcp
 ```
 
-In the **MCPB Custom Headers** field, the value is just typed line by line — no escape sequences needed.
+```cmd
+:: Windows CMD — double quotes don't expand \n, so use the literal escape
+::               and the proxy will interpret it (see "Escape fallback" below).
+set MCP_HEADERS=X-API-Key: secret\nX-Tenant: acme
+```
+
+```powershell
+# Windows PowerShell — backtick-n is the PowerShell newline escape
+$env:MCP_HEADERS = "X-API-Key: secret`nX-Tenant: acme"
+```
+
+In the **MCPB Custom Headers** field, Claude Desktop currently exposes only a single-line input, so type the literal two-character `\n` sequence between entries (e.g. `X-API-Key: secret\nX-Tenant: acme`). Once Claude Desktop ships multi-line text inputs in `user_config`, the same value can be entered as real line breaks.
+
+##### Escape fallback (literal `\n`)
+
+When the value passed to the binary contains **no real newlines**, the proxy interprets the literal two-character sequence `\n` (backslash + `n`) as a separator. This covers contexts that cannot embed real newlines: the MCPB single-line UI, Windows CMD, and plain-double-quote shells. As soon as a real newline is present, the literal `\n` is **left untouched** so a header value that legitimately contains `\n` survives unchanged.
 
 Blank lines and lines without `:` are ignored (the latter logs a warning), so a typo in one entry never blocks the others.
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,20 @@ The easiest way to use with Claude Desktop is via the `.mcpb` extension. After i
 | OAuth Callback Port | Local port for OAuth callback | `3334` |
 | Allow HTTP | Allow insecure HTTP connections | `false` |
 | HTTP/HTTPS Proxy | Proxy server URL (e.g. `http://proxy:8080`) | — |
-| Authorization Header | Auth header value (stored securely) | — |
+| Authorization Header Value | **Value portion only** — do NOT prepend `Authorization:`. Examples: `Bearer eyJhbGc...`, `Basic dXNlcjpwYXNz` | — |
+| Custom Headers | Additional headers, one per line as `Name: Value`. Use this for `X-API-Key`, tenant IDs, etc. Authorization goes in the field above. | — |
+
+#### Format notes
+
+The same value can be entered three ways depending on how you launch the proxy. Each path uses a slightly different format:
+
+| Where | Authorization header | Other headers |
+|---|---|---|
+| MCPB UI (above) | `Authorization Header Value` field — **value only** (`Bearer xxx`) | `Custom Headers` field — `Name: Value` per line |
+| CLI `--header` (repeatable) | Full header: `--header "Authorization: Bearer xxx"` | Full header: `--header "X-API-Key: secret"` |
+| Env vars | `MCP_AUTH_HEADER="Bearer xxx"` (value only) | `MCP_HEADERS=$'X-API-Key: secret\nX-Tenant: acme'` (newline-separated, full `Name: Value` per line) |
+
+If `MCP_HEADERS` already contains an `Authorization:` line, `MCP_AUTH_HEADER` is ignored to avoid duplicates.
 
 ### Claude Desktop (Manual Configuration)
 
@@ -287,7 +300,8 @@ All options can also be set via environment variables. CLI flags take precedence
 | `MCP_PORT` | OAuth callback port | `--port` |
 | `MCP_ALLOW_HTTP` | Set to `true` to allow HTTP | `--allow-http` |
 | `MCP_HTTPS_PROXY` | HTTP/HTTPS proxy URL | `--https-proxy` |
-| `MCP_AUTH_HEADER` | Authorization header value | `--header "Authorization: ..."` |
+| `MCP_AUTH_HEADER` | Authorization header **value only** (e.g. `Bearer xxx`) — the proxy prepends `Authorization:` automatically | `--header "Authorization: ..."` |
+| `MCP_HEADERS` | Newline-separated `Name: Value` list for arbitrary headers (e.g. `X-API-Key: secret`) | One `--header "Name: Value"` per entry |
 
 These environment variables are used internally by the MCPB extension to pass GUI-configured values to the binary.
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ The easiest way to use with Claude Desktop is via the `.mcpb` extension. After i
 | Allow HTTP | Allow insecure HTTP connections | `false` |
 | HTTP/HTTPS Proxy | Proxy server URL (e.g. `http://proxy:8080`) | — |
 | Authorization Header Value | **Value portion only** — do NOT prepend `Authorization:`. Examples: `Bearer eyJhbGc...`, `Basic dXNlcjpwYXNz` | — |
-| Custom Headers | Additional headers as `Name: Value`. Because Claude Desktop's text field is single-line, separate multiple headers with the literal two-character sequence `\n` (e.g. `X-API-Key: secret\nX-Tenant: acme`). Use this for `X-API-Key`, tenant IDs, etc.; Authorization goes in the field above. | — |
+| Custom Header 1–5 — Name / Value | Up to five additional headers, one per Name/Value field pair. Put the header name (e.g. `X-API-Key`) in the Name field — it stays visible so you can see which headers are configured — and the value in the Value field, which is stored encrypted and masked. Leave the Name blank to skip a row. Authorization goes in the field above. | — |
 
 #### Format notes
 
@@ -149,7 +149,7 @@ The same value can be entered three ways depending on how you launch the proxy. 
 
 | Where | Authorization header | Other headers |
 |---|---|---|
-| MCPB UI (above) | `Authorization Header Value` field — **value only** (`Bearer xxx`) | `Custom Headers` field — `Name: Value` per line |
+| MCPB UI (above) | `Authorization Header Value` field — **value only** (`Bearer xxx`) | `Custom Header N` field pairs — name and value in separate fields |
 | CLI `--header` (repeat the flag) | `--header "Authorization: Bearer xxx"` | `--header "X-API-Key: secret"` |
 | Env vars | `MCP_AUTH_HEADER="Bearer xxx"` (value only) | `MCP_HEADERS` — newline-separated `Name: Value` per line (see examples below) |
 
@@ -216,11 +216,11 @@ set MCP_HEADERS=X-API-Key: secret\nX-Tenant: acme
 $env:MCP_HEADERS = "X-API-Key: secret`nX-Tenant: acme"
 ```
 
-In the **MCPB Custom Headers** field, Claude Desktop currently exposes only a single-line input, so type the literal two-character `\n` sequence between entries (e.g. `X-API-Key: secret\nX-Tenant: acme`). Once Claude Desktop ships multi-line text inputs in `user_config`, the same value can be entered as real line breaks.
+The MCPB UI does not use `MCP_HEADERS`; each `Custom Header N` Name/Value pair is passed to the proxy separately, so no separator is needed there.
 
 ##### Escape fallback (literal `\n`)
 
-When the value passed to the binary contains **no real newlines**, the proxy interprets the literal two-character sequence `\n` (backslash + `n`) as a separator. This covers contexts that cannot embed real newlines: the MCPB single-line UI, Windows CMD, and plain-double-quote shells. As soon as a real newline is present, the literal `\n` is **left untouched** so a header value that legitimately contains `\n` survives unchanged.
+When the value passed to the binary contains **no real newlines**, the proxy interprets the literal two-character sequence `\n` (backslash + `n`) as a separator. This covers contexts that cannot embed real newlines: Windows CMD and plain-double-quote shells. As soon as a real newline is present, the literal `\n` is **left untouched** so a header value that legitimately contains `\n` survives unchanged.
 
 Blank lines and lines without `:` are ignored (the latter logs a warning), so a typo in one entry never blocks the others.
 

--- a/README.md
+++ b/README.md
@@ -83,8 +83,15 @@ mcp-remote-go https://remote.mcp.server/sse --transport sse
 # With custom port for OAuth callback
 mcp-remote-go https://remote.mcp.server/mcp 9090
 
-# With custom headers (useful for auth bypass or adding auth tokens)
+# With a custom header (useful for auth tokens, API keys, etc.)
 mcp-remote-go https://remote.mcp.server/mcp --header "Authorization: Bearer YOUR_TOKEN"
+
+# Multiple headers — repeat --header as many times as needed
+# (Note: there is no --headers plural flag; `--header` takes one Name:Value at a time.)
+mcp-remote-go https://remote.mcp.server/mcp \
+  --header "Authorization: Bearer YOUR_TOKEN" \
+  --header "X-API-Key: secret" \
+  --header "X-Tenant-Id: acme"
 
 # Allow HTTP for trusted networks (normally HTTPS is required)
 mcp-remote-go http://internal.mcp.server/mcp --allow-http
@@ -143,10 +150,64 @@ The same value can be entered three ways depending on how you launch the proxy. 
 | Where | Authorization header | Other headers |
 |---|---|---|
 | MCPB UI (above) | `Authorization Header Value` field — **value only** (`Bearer xxx`) | `Custom Headers` field — `Name: Value` per line |
-| CLI `--header` (repeatable) | Full header: `--header "Authorization: Bearer xxx"` | Full header: `--header "X-API-Key: secret"` |
-| Env vars | `MCP_AUTH_HEADER="Bearer xxx"` (value only) | `MCP_HEADERS=$'X-API-Key: secret\nX-Tenant: acme'` (newline-separated, full `Name: Value` per line) |
+| CLI `--header` (repeat the flag) | `--header "Authorization: Bearer xxx"` | `--header "X-API-Key: secret"` |
+| Env vars | `MCP_AUTH_HEADER="Bearer xxx"` (value only) | `MCP_HEADERS` — newline-separated `Name: Value` per line (see examples below) |
+
+> **There is no `--headers` (plural) flag.** Pass each header as its own `--header "Name: Value"`; repeat the flag for multiple headers.
 
 If `MCP_HEADERS` already contains an `Authorization:` line, `MCP_AUTH_HEADER` is ignored to avoid duplicates.
+
+##### Writing `MCP_HEADERS` in different contexts
+
+Embedding newlines in a single env-var value looks different in each tool. All of the following set the same two headers (`X-API-Key: secret` and `X-Tenant: acme`):
+
+```bash
+# bash / zsh — $'...' is ANSI-C quoting that turns \n into a real newline
+export MCP_HEADERS=$'X-API-Key: secret\nX-Tenant: acme'
+```
+
+```bash
+# Portable shell — leave the double quotes open across a real newline
+export MCP_HEADERS="X-API-Key: secret
+X-Tenant: acme"
+```
+
+```json
+// Claude Desktop manual config — JSON \n is interpreted as a real newline
+{
+  "mcpServers": {
+    "remote-example": {
+      "command": "/path/to/mcp-remote-go",
+      "args": ["https://remote.mcp.server/mcp"],
+      "env": {
+        "MCP_HEADERS": "X-API-Key: secret\nX-Tenant: acme"
+      }
+    }
+  }
+}
+```
+
+```yaml
+# docker-compose — YAML block scalar (|) preserves newlines
+services:
+  mcp-remote:
+    image: ghcr.io/naotama2002/mcp-remote-go:latest
+    environment:
+      MCP_HEADERS: |
+        X-API-Key: secret
+        X-Tenant: acme
+```
+
+```bash
+# docker run — same $'...' trick as bash/zsh
+docker run --rm -it \
+  -e MCP_HEADERS=$'X-API-Key: secret\nX-Tenant: acme' \
+  ghcr.io/naotama2002/mcp-remote-go:latest https://remote.mcp.server/mcp
+```
+
+In the **MCPB Custom Headers** field, the value is just typed line by line — no escape sequences needed.
+
+Blank lines and lines without `:` are ignored (the latter logs a warning), so a typo in one entry never blocks the others.
 
 ### Claude Desktop (Manual Configuration)
 

--- a/cmd/mcp-remote-go/args_test.go
+++ b/cmd/mcp-remote-go/args_test.go
@@ -454,6 +454,50 @@ func TestApplyEnvOverrides_HeadersPlusAuthHeaderCombine(t *testing.T) {
 	}
 }
 
+// TestApplyEnvOverrides_HeadersEscapedNewlineFallback covers the case where
+// the platform cannot embed real newlines in an env var (MCPB single-line
+// text field, Windows CMD double quotes, regular bash double quotes) so the
+// caller resorts to the literal "\n" two-character escape sequence.
+func TestApplyEnvOverrides_HeadersEscapedNewlineFallback(t *testing.T) {
+	t.Setenv("MCP_HEADERS", `X-A: 1\nX-B: 2\nX-C: 3`)
+
+	headers := flagList{}
+	serverURL, port, allowHTTP, transport, httpProxy := "", 3334, false, "auto", ""
+	applyEnvOverrides(&serverURL, &port, &allowHTTP, &transport, &httpProxy, &headers)
+
+	want := []string{"X-A: 1", "X-B: 2", "X-C: 3"}
+	if len(headers) != len(want) {
+		t.Fatalf("got %d headers, want %d: %v", len(headers), len(want), headers)
+	}
+	for i, h := range want {
+		if headers[i] != h {
+			t.Errorf("headers[%d] = %q, want %q", i, headers[i], h)
+		}
+	}
+}
+
+// TestApplyEnvOverrides_HeadersRealNewlinePreservesLiteralBackslashN ensures
+// that when real newlines are present the literal "\n" sequence is NOT
+// reinterpreted, so a header value legitimately containing those two
+// characters survives unchanged.
+func TestApplyEnvOverrides_HeadersRealNewlinePreservesLiteralBackslashN(t *testing.T) {
+	t.Setenv("MCP_HEADERS", "X-Weird: foo\\nbar\nX-Plain: ok")
+
+	headers := flagList{}
+	serverURL, port, allowHTTP, transport, httpProxy := "", 3334, false, "auto", ""
+	applyEnvOverrides(&serverURL, &port, &allowHTTP, &transport, &httpProxy, &headers)
+
+	want := []string{`X-Weird: foo\nbar`, "X-Plain: ok"}
+	if len(headers) != len(want) {
+		t.Fatalf("got %d headers, want %d: %v", len(headers), len(want), headers)
+	}
+	for i, h := range want {
+		if headers[i] != h {
+			t.Errorf("headers[%d] = %q, want %q", i, headers[i], h)
+		}
+	}
+}
+
 // TestApplyEnvOverrides_HeadersAuthorizationSuppressesAuthHeader verifies that
 // when MCP_HEADERS already carries an Authorization line, the legacy
 // MCP_AUTH_HEADER does not also append a duplicate.

--- a/cmd/mcp-remote-go/args_test.go
+++ b/cmd/mcp-remote-go/args_test.go
@@ -516,3 +516,92 @@ func TestApplyEnvOverrides_HeadersAuthorizationSuppressesAuthHeader(t *testing.T
 		t.Errorf("headers[0] = %q, want %q", headers[0], "Authorization: Bearer from-headers")
 	}
 }
+
+func TestApplyEnvOverrides_NumberedHeadersAppend(t *testing.T) {
+	// MCPB per-row Custom Header fields arrive as MCP_HEADER_1..5.
+	t.Setenv("MCP_HEADER_1", "X-API-Key: key1")
+	t.Setenv("MCP_HEADER_3", "X-Tenant: acme")
+
+	headers := flagList{}
+	serverURL, port, allowHTTP, transport, httpProxy := "", 3334, false, "auto", ""
+	applyEnvOverrides(&serverURL, &port, &allowHTTP, &transport, &httpProxy, &headers)
+
+	want := []string{"X-API-Key: key1", "X-Tenant: acme"}
+	if len(headers) != len(want) {
+		t.Fatalf("got %d headers, want %d: %v", len(headers), len(want), headers)
+	}
+	for i, h := range want {
+		if headers[i] != h {
+			t.Errorf("headers[%d] = %q, want %q", i, headers[i], h)
+		}
+	}
+}
+
+func TestApplyEnvOverrides_NumberedHeaderEmptyNameSkipped(t *testing.T) {
+	// An unused MCPB row where only the sensitive value field was filled
+	// arrives as a bare ":value" and must not produce an empty-name header.
+	t.Setenv("MCP_HEADER_1", ": orphan-value")
+	t.Setenv("MCP_HEADER_2", "X-Real: ok")
+
+	headers := flagList{}
+	serverURL, port, allowHTTP, transport, httpProxy := "", 3334, false, "auto", ""
+	applyEnvOverrides(&serverURL, &port, &allowHTTP, &transport, &httpProxy, &headers)
+
+	if len(headers) != 1 || headers[0] != "X-Real: ok" {
+		t.Fatalf("expected only the named header, got %v", headers)
+	}
+}
+
+func TestApplyEnvOverrides_NumberedHeaderUnsubstitutedPlaceholderSkipped(t *testing.T) {
+	// Claude Desktop leaves "${user_config.NAME}" literally in place when an
+	// optional field is blank. Such rows must be ignored, not sent as headers.
+	t.Setenv("MCP_HEADER_1", "${user_config.header_1_name}: ${user_config.header_1_value}")
+	t.Setenv("MCP_HEADER_2", "X-Real: ok")
+
+	headers := flagList{}
+	serverURL, port, allowHTTP, transport, httpProxy := "", 3334, false, "auto", ""
+	applyEnvOverrides(&serverURL, &port, &allowHTTP, &transport, &httpProxy, &headers)
+
+	if len(headers) != 1 || headers[0] != "X-Real: ok" {
+		t.Fatalf("expected only the resolved header, got %v", headers)
+	}
+}
+
+func TestApplyEnvOverrides_NumberedHeaderInvalidNameSkipped(t *testing.T) {
+	// A human-readable label typed into the header-name field (spaces are not
+	// valid in an HTTP header name) must be skipped, not crash the connection.
+	t.Setenv("MCP_HEADER_1", "Redash API Key: secret-token")
+	t.Setenv("MCP_HEADER_2", "X-Redash-API-Key: secret-token")
+
+	headers := flagList{}
+	serverURL, port, allowHTTP, transport, httpProxy := "", 3334, false, "auto", ""
+	applyEnvOverrides(&serverURL, &port, &allowHTTP, &transport, &httpProxy, &headers)
+
+	if len(headers) != 1 || headers[0] != "X-Redash-API-Key: secret-token" {
+		t.Fatalf("expected only the valid header, got %v", headers)
+	}
+}
+
+func TestApplyEnvOverrides_ProxyUnsubstitutedPlaceholderSkipped(t *testing.T) {
+	t.Setenv("MCP_HTTPS_PROXY", "${user_config.http_proxy}")
+
+	headers := flagList{}
+	serverURL, port, allowHTTP, transport, httpProxy := "", 3334, false, "auto", ""
+	applyEnvOverrides(&serverURL, &port, &allowHTTP, &transport, &httpProxy, &headers)
+
+	if httpProxy != "" {
+		t.Fatalf("expected proxy to stay unset, got %q", httpProxy)
+	}
+}
+
+func TestApplyEnvOverrides_AuthHeaderUnsubstitutedPlaceholderSkipped(t *testing.T) {
+	t.Setenv("MCP_AUTH_HEADER", "${user_config.auth_header}")
+
+	headers := flagList{}
+	serverURL, port, allowHTTP, transport, httpProxy := "", 3334, false, "auto", ""
+	applyEnvOverrides(&serverURL, &port, &allowHTTP, &transport, &httpProxy, &headers)
+
+	if len(headers) != 0 {
+		t.Fatalf("expected no headers, got %v", headers)
+	}
+}

--- a/cmd/mcp-remote-go/args_test.go
+++ b/cmd/mcp-remote-go/args_test.go
@@ -567,6 +567,38 @@ func TestApplyEnvOverrides_NumberedHeaderUnsubstitutedPlaceholderSkipped(t *test
 	}
 }
 
+func TestApplyEnvOverrides_HeadersAuthorizationWithSpaceSuppressesAuthHeader(t *testing.T) {
+	// Whitespace around the colon must not defeat duplicate detection:
+	// headerMap construction trims both sides to the same "Authorization" key.
+	t.Setenv("MCP_HEADERS", "Authorization : Bearer from-headers")
+	t.Setenv("MCP_AUTH_HEADER", "Bearer from-auth-header")
+
+	headers := flagList{}
+	serverURL, port, allowHTTP, transport, httpProxy := "", 3334, false, "auto", ""
+	applyEnvOverrides(&serverURL, &port, &allowHTTP, &transport, &httpProxy, &headers)
+
+	if len(headers) != 1 {
+		t.Fatalf("expected 1 header, got %d: %v", len(headers), headers)
+	}
+	if headers[0] != "Authorization : Bearer from-headers" {
+		t.Errorf("headers[0] = %q, want the MCP_HEADERS entry", headers[0])
+	}
+}
+
+func TestApplyEnvOverrides_ProxyWithNonMCPBPlaceholderKept(t *testing.T) {
+	// Only unsubstituted "${user_config.*}" templates are treated as unset;
+	// other "${...}" content is a legitimate value and must pass through.
+	t.Setenv("MCP_HTTPS_PROXY", "http://${HOST}:8080")
+
+	headers := flagList{}
+	serverURL, port, allowHTTP, transport, httpProxy := "", 3334, false, "auto", ""
+	applyEnvOverrides(&serverURL, &port, &allowHTTP, &transport, &httpProxy, &headers)
+
+	if httpProxy != "http://${HOST}:8080" {
+		t.Fatalf("expected proxy to pass through, got %q", httpProxy)
+	}
+}
+
 func TestApplyEnvOverrides_NumberedHeaderInvalidNameSkipped(t *testing.T) {
 	// A human-readable label typed into the header-name field (spaces are not
 	// valid in an HTTP header name) must be skipped, not crash the connection.

--- a/cmd/mcp-remote-go/args_test.go
+++ b/cmd/mcp-remote-go/args_test.go
@@ -392,3 +392,83 @@ func TestApplyEnvOverrides_AuthHeaderCLITakesPrecedence(t *testing.T) {
 		t.Errorf("Expected CLI auth header, got '%s'", headers[0])
 	}
 }
+
+func TestApplyEnvOverrides_HeadersAppendsMultiple(t *testing.T) {
+	t.Setenv("MCP_HEADERS", "X-API-Key: key1\nX-Tenant: acme")
+
+	serverURL := ""
+	port := 3334
+	allowHTTP := false
+	transport := "auto"
+	httpProxy := ""
+	headers := flagList{}
+
+	applyEnvOverrides(&serverURL, &port, &allowHTTP, &transport, &httpProxy, &headers)
+
+	want := []string{"X-API-Key: key1", "X-Tenant: acme"}
+	if len(headers) != len(want) {
+		t.Fatalf("got %d headers, want %d: %v", len(headers), len(want), headers)
+	}
+	for i, h := range want {
+		if headers[i] != h {
+			t.Errorf("headers[%d] = %q, want %q", i, headers[i], h)
+		}
+	}
+}
+
+func TestApplyEnvOverrides_HeadersIgnoresBlanksAndInvalidLines(t *testing.T) {
+	// CRLF, blank lines, and a line without ':' should be skipped.
+	t.Setenv("MCP_HEADERS", "\r\nX-A: 1\r\n\r\nnocolon\r\nX-B: 2\r\n")
+
+	headers := flagList{}
+	serverURL, port, allowHTTP, transport, httpProxy := "", 3334, false, "auto", ""
+	applyEnvOverrides(&serverURL, &port, &allowHTTP, &transport, &httpProxy, &headers)
+
+	want := []string{"X-A: 1", "X-B: 2"}
+	if len(headers) != 2 {
+		t.Fatalf("got %d headers, want %d: %v", len(headers), len(want), headers)
+	}
+	for i, h := range want {
+		if headers[i] != h {
+			t.Errorf("headers[%d] = %q, want %q", i, headers[i], h)
+		}
+	}
+}
+
+func TestApplyEnvOverrides_HeadersPlusAuthHeaderCombine(t *testing.T) {
+	t.Setenv("MCP_HEADERS", "X-API-Key: secret")
+	t.Setenv("MCP_AUTH_HEADER", "Bearer token")
+
+	headers := flagList{}
+	serverURL, port, allowHTTP, transport, httpProxy := "", 3334, false, "auto", ""
+	applyEnvOverrides(&serverURL, &port, &allowHTTP, &transport, &httpProxy, &headers)
+
+	want := []string{"X-API-Key: secret", "Authorization:Bearer token"}
+	if len(headers) != len(want) {
+		t.Fatalf("got %d headers, want %d: %v", len(headers), len(want), headers)
+	}
+	for i, h := range want {
+		if headers[i] != h {
+			t.Errorf("headers[%d] = %q, want %q", i, headers[i], h)
+		}
+	}
+}
+
+// TestApplyEnvOverrides_HeadersAuthorizationSuppressesAuthHeader verifies that
+// when MCP_HEADERS already carries an Authorization line, the legacy
+// MCP_AUTH_HEADER does not also append a duplicate.
+func TestApplyEnvOverrides_HeadersAuthorizationSuppressesAuthHeader(t *testing.T) {
+	t.Setenv("MCP_HEADERS", "Authorization: Bearer from-headers")
+	t.Setenv("MCP_AUTH_HEADER", "Bearer from-auth-header")
+
+	headers := flagList{}
+	serverURL, port, allowHTTP, transport, httpProxy := "", 3334, false, "auto", ""
+	applyEnvOverrides(&serverURL, &port, &allowHTTP, &transport, &httpProxy, &headers)
+
+	if len(headers) != 1 {
+		t.Fatalf("expected 1 header, got %d: %v", len(headers), headers)
+	}
+	if headers[0] != "Authorization: Bearer from-headers" {
+		t.Errorf("headers[0] = %q, want %q", headers[0], "Authorization: Bearer from-headers")
+	}
+}

--- a/cmd/mcp-remote-go/main.go
+++ b/cmd/mcp-remote-go/main.go
@@ -199,7 +199,7 @@ func parseRemainingArgs(remaining []string, defaults cliConfig) cliConfig {
 // names (e.g. `invalid header field name "${user_config.header_2_name}"`).
 func mcpbEnv(name string) string {
 	v := os.Getenv(name)
-	if strings.Contains(v, "${") {
+	if strings.Contains(v, "${user_config.") {
 		return ""
 	}
 	return v
@@ -225,7 +225,7 @@ func applyEnvOverrides(serverURL *string, callbackPort *int, allowHTTP *bool, tr
 	if os.Getenv("MCP_ALLOW_HTTP") == "true" && !*allowHTTP {
 		*allowHTTP = true
 	}
-	if v := os.Getenv("MCP_HEADERS"); v != "" {
+	if v := mcpbEnv("MCP_HEADERS"); v != "" {
 		for _, h := range parseHeaderLines(v) {
 			*headers = append(*headers, h)
 		}
@@ -245,7 +245,12 @@ func applyEnvOverrides(serverURL *string, callbackPort *int, allowHTTP *bool, tr
 	if v := mcpbEnv("MCP_AUTH_HEADER"); v != "" {
 		hasAuth := false
 		for _, h := range *headers {
-			if strings.HasPrefix(strings.ToLower(h), "authorization:") {
+			// Compare the parsed header name rather than a string prefix:
+			// entries may carry whitespace around the colon (e.g.
+			// "Authorization : Bearer ..."), which headerMap construction
+			// later trims to the same key.
+			name, _, found := strings.Cut(h, ":")
+			if found && strings.EqualFold(strings.TrimSpace(name), "Authorization") {
 				hasAuth = true
 				break
 			}
@@ -280,7 +285,7 @@ func parseHeaderLines(raw string) []string {
 		}
 		idx := strings.Index(line, ":")
 		if idx < 0 {
-			log.Printf("Warning: ignoring MCP_HEADERS entry without ':' separator: %q", line)
+			log.Printf("Warning: ignoring header entry without ':' separator: %q", line)
 			continue
 		}
 		name := strings.TrimSpace(line[:idx])

--- a/cmd/mcp-remote-go/main.go
+++ b/cmd/mcp-remote-go/main.go
@@ -235,7 +235,17 @@ func applyEnvOverrides(serverURL *string, callbackPort *int, allowHTTP *bool, tr
 // field. Empty lines are ignored. Lines that do not contain a colon are logged
 // and skipped so a typo in one entry does not prevent the others from being
 // applied.
+//
+// As a convenience for contexts that cannot embed real newlines in an env
+// var value (Claude Desktop's MCPB single-line text field, Windows CMD
+// double quotes, etc.), a literal "\n" two-character sequence is also
+// treated as a separator — but only when no real newline is present, so an
+// HTTP header value legitimately containing "\n" in a real-newline payload
+// is left untouched.
 func parseHeaderLines(raw string) []string {
+	if !strings.ContainsAny(raw, "\r\n") {
+		raw = strings.ReplaceAll(raw, `\n`, "\n")
+	}
 	var out []string
 	for _, line := range strings.FieldsFunc(raw, func(r rune) bool { return r == '\n' || r == '\r' }) {
 		line = strings.TrimSpace(line)

--- a/cmd/mcp-remote-go/main.go
+++ b/cmd/mcp-remote-go/main.go
@@ -211,6 +211,11 @@ func applyEnvOverrides(serverURL *string, callbackPort *int, allowHTTP *bool, tr
 	if os.Getenv("MCP_ALLOW_HTTP") == "true" && !*allowHTTP {
 		*allowHTTP = true
 	}
+	if v := os.Getenv("MCP_HEADERS"); v != "" {
+		for _, h := range parseHeaderLines(v) {
+			*headers = append(*headers, h)
+		}
+	}
 	if v := os.Getenv("MCP_AUTH_HEADER"); v != "" {
 		hasAuth := false
 		for _, h := range *headers {
@@ -223,4 +228,25 @@ func applyEnvOverrides(serverURL *string, callbackPort *int, allowHTTP *bool, tr
 			*headers = append(*headers, "Authorization:"+v)
 		}
 	}
+}
+
+// parseHeaderLines parses a newline-separated list of `Name: Value` header
+// entries, as accepted by the MCP_HEADERS env var and the MCPB Custom Headers
+// field. Empty lines are ignored. Lines that do not contain a colon are logged
+// and skipped so a typo in one entry does not prevent the others from being
+// applied.
+func parseHeaderLines(raw string) []string {
+	var out []string
+	for _, line := range strings.FieldsFunc(raw, func(r rune) bool { return r == '\n' || r == '\r' }) {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if !strings.Contains(line, ":") {
+			log.Printf("Warning: ignoring MCP_HEADERS entry without ':' separator: %q", line)
+			continue
+		}
+		out = append(out, line)
+	}
+	return out
 }

--- a/cmd/mcp-remote-go/main.go
+++ b/cmd/mcp-remote-go/main.go
@@ -191,21 +191,35 @@ func parseRemainingArgs(remaining []string, defaults cliConfig) cliConfig {
 }
 
 // applyEnvOverrides reads environment variables and applies them as overrides.
+// mcpbEnv reads an environment variable populated by MCPB user_config
+// substitution. When an optional user_config field is left blank, the host
+// (Claude Desktop) does not substitute it and the literal "${user_config.NAME}"
+// template string reaches the process instead of an empty value. Such values
+// must be treated as unset, otherwise they leak into proxy URLs and header
+// names (e.g. `invalid header field name "${user_config.header_2_name}"`).
+func mcpbEnv(name string) string {
+	v := os.Getenv(name)
+	if strings.Contains(v, "${") {
+		return ""
+	}
+	return v
+}
+
 // Environment variables are used by MCPB user_config to pass GUI-configured values.
 // CLI flags take precedence; env vars only apply when the corresponding flag is at its default.
 func applyEnvOverrides(serverURL *string, callbackPort *int, allowHTTP *bool, transportMode *string, httpProxy *string, headers *flagList) {
-	if v := os.Getenv("MCP_SERVER_URL"); v != "" && *serverURL == "" {
+	if v := mcpbEnv("MCP_SERVER_URL"); v != "" && *serverURL == "" {
 		*serverURL = v
 	}
-	if v := os.Getenv("MCP_TRANSPORT"); v != "" && *transportMode == "auto" {
+	if v := mcpbEnv("MCP_TRANSPORT"); v != "" && *transportMode == "auto" {
 		*transportMode = v
 	}
-	if v := os.Getenv("MCP_PORT"); v != "" && *callbackPort == 3334 {
+	if v := mcpbEnv("MCP_PORT"); v != "" && *callbackPort == 3334 {
 		if _, err := fmt.Sscanf(v, "%d", callbackPort); err != nil {
 			log.Printf("Warning: failed to parse MCP_PORT: %v", err)
 		}
 	}
-	if v := os.Getenv("MCP_HTTPS_PROXY"); v != "" && *httpProxy == "" {
+	if v := mcpbEnv("MCP_HTTPS_PROXY"); v != "" && *httpProxy == "" {
 		*httpProxy = v
 	}
 	if os.Getenv("MCP_ALLOW_HTTP") == "true" && !*allowHTTP {
@@ -216,7 +230,19 @@ func applyEnvOverrides(serverURL *string, callbackPort *int, allowHTTP *bool, tr
 			*headers = append(*headers, h)
 		}
 	}
-	if v := os.Getenv("MCP_AUTH_HEADER"); v != "" {
+	// MCP_HEADER_1..MCP_HEADER_5 carry one `Name: Value` entry each. They back
+	// the per-row Custom Header fields in the MCPB manifest, where the value
+	// portion is marked sensitive. Unused rows arrive either empty, as a bare
+	// ":" (only the value field filled), or with unsubstituted "${...}"
+	// placeholders — mcpbEnv drops the last case and parseHeaderLines the rest.
+	for i := 1; i <= 5; i++ {
+		if v := mcpbEnv(fmt.Sprintf("MCP_HEADER_%d", i)); v != "" {
+			for _, h := range parseHeaderLines(v) {
+				*headers = append(*headers, h)
+			}
+		}
+	}
+	if v := mcpbEnv("MCP_AUTH_HEADER"); v != "" {
 		hasAuth := false
 		for _, h := range *headers {
 			if strings.HasPrefix(strings.ToLower(h), "authorization:") {
@@ -231,10 +257,10 @@ func applyEnvOverrides(serverURL *string, callbackPort *int, allowHTTP *bool, tr
 }
 
 // parseHeaderLines parses a newline-separated list of `Name: Value` header
-// entries, as accepted by the MCP_HEADERS env var and the MCPB Custom Headers
-// field. Empty lines are ignored. Lines that do not contain a colon are logged
-// and skipped so a typo in one entry does not prevent the others from being
-// applied.
+// entries, as accepted by the MCP_HEADERS and MCP_HEADER_1..5 env vars. Empty
+// lines and lines with an empty header name are ignored. Lines that do not
+// contain a colon are logged and skipped so a typo in one entry does not
+// prevent the others from being applied.
 //
 // As a convenience for contexts that cannot embed real newlines in an env
 // var value (Claude Desktop's MCPB single-line text field, Windows CMD
@@ -252,11 +278,43 @@ func parseHeaderLines(raw string) []string {
 		if line == "" {
 			continue
 		}
-		if !strings.Contains(line, ":") {
+		idx := strings.Index(line, ":")
+		if idx < 0 {
 			log.Printf("Warning: ignoring MCP_HEADERS entry without ':' separator: %q", line)
+			continue
+		}
+		name := strings.TrimSpace(line[:idx])
+		if name == "" {
+			// Empty header name, e.g. an unused MCPB row where only the
+			// sensitive value field was filled in. Skip silently.
+			continue
+		}
+		if !isValidHeaderName(name) {
+			// e.g. a human-readable label like "Redash API Key" typed into the
+			// header-name field. Sending it would make net/http reject the whole
+			// request, so skip this entry and keep the others.
+			log.Printf("Warning: ignoring header entry with invalid header name %q (HTTP header names cannot contain spaces or special characters)", name)
 			continue
 		}
 		out = append(out, line)
 	}
 	return out
+}
+
+// isValidHeaderName reports whether name is a valid RFC 7230 header field name
+// (a non-empty "token": ASCII letters, digits, and a limited set of symbols,
+// with no spaces or control characters).
+func isValidHeaderName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+		case strings.ContainsRune("!#$%&'*+-.^_`|~", r):
+		default:
+			return false
+		}
+	}
+	return true
 }

--- a/scripts/build-mcpb.sh
+++ b/scripts/build-mcpb.sh
@@ -70,7 +70,8 @@ for platform in "${PLATFORMS[@]}"; do
       "env": {
         "MCP_ALLOW_HTTP": "\${user_config.allow_http}",
         "MCP_HTTPS_PROXY": "\${user_config.http_proxy}",
-        "MCP_AUTH_HEADER": "\${user_config.auth_header}"
+        "MCP_AUTH_HEADER": "\${user_config.auth_header}",
+        "MCP_HEADERS": "\${user_config.custom_headers}"
       }
     }
   },
@@ -108,8 +109,15 @@ for platform in "${PLATFORMS[@]}"; do
     },
     "auth_header": {
       "type": "string",
-      "title": "Authorization Header",
-      "description": "Custom Authorization header value (e.g. Bearer your-token-here)",
+      "title": "Authorization Header Value",
+      "description": "Value portion only — do NOT prepend \"Authorization:\". Examples: \"Bearer eyJhbGc...\" or \"Basic dXNlcjpwYXNz\".",
+      "sensitive": true
+    },
+    "custom_headers": {
+      "type": "string",
+      "title": "Custom Headers",
+      "description": "Additional request headers, one per line as \"Name: Value\" (e.g. \"X-API-Key: secret\\nX-Tenant: acme\"). Use the field above for the Authorization header.",
+      "multiline": true,
       "sensitive": true
     }
   },

--- a/scripts/build-mcpb.sh
+++ b/scripts/build-mcpb.sh
@@ -116,8 +116,7 @@ for platform in "${PLATFORMS[@]}"; do
     "custom_headers": {
       "type": "string",
       "title": "Custom Headers",
-      "description": "Additional request headers, one per line as \"Name: Value\" (e.g. \"X-API-Key: secret\\nX-Tenant: acme\"). Use the field above for the Authorization header.",
-      "multiline": true,
+      "description": "Additional request headers. Type each entry as \"Name: Value\" separated by the literal two-character sequence \\n (e.g. \"X-API-Key: secret\\nX-Tenant: acme\"). Use the field above for the Authorization header.",
       "sensitive": true
     }
   },

--- a/scripts/build-mcpb.sh
+++ b/scripts/build-mcpb.sh
@@ -71,7 +71,11 @@ for platform in "${PLATFORMS[@]}"; do
         "MCP_ALLOW_HTTP": "\${user_config.allow_http}",
         "MCP_HTTPS_PROXY": "\${user_config.http_proxy}",
         "MCP_AUTH_HEADER": "\${user_config.auth_header}",
-        "MCP_HEADERS": "\${user_config.custom_headers}"
+        "MCP_HEADER_1": "\${user_config.header_1_name}: \${user_config.header_1_value}",
+        "MCP_HEADER_2": "\${user_config.header_2_name}: \${user_config.header_2_value}",
+        "MCP_HEADER_3": "\${user_config.header_3_name}: \${user_config.header_3_value}",
+        "MCP_HEADER_4": "\${user_config.header_4_name}: \${user_config.header_4_value}",
+        "MCP_HEADER_5": "\${user_config.header_5_name}: \${user_config.header_5_value}"
       }
     }
   },
@@ -113,10 +117,59 @@ for platform in "${PLATFORMS[@]}"; do
       "description": "Value portion only — do NOT prepend \"Authorization:\". Examples: \"Bearer eyJhbGc...\" or \"Basic dXNlcjpwYXNz\".",
       "sensitive": true
     },
-    "custom_headers": {
+    "header_1_name": {
       "type": "string",
-      "title": "Custom Headers",
-      "description": "Additional request headers. Type each entry as \"Name: Value\" separated by the literal two-character sequence \\n (e.g. \"X-API-Key: secret\\nX-Tenant: acme\"). Use the field above for the Authorization header.",
+      "title": "Custom Header 1 — Name",
+      "description": "Header name, e.g. X-API-Key. Leave blank to skip this row."
+    },
+    "header_1_value": {
+      "type": "string",
+      "title": "Custom Header 1 — Value",
+      "description": "Header value for the name above. Hidden after entry.",
+      "sensitive": true
+    },
+    "header_2_name": {
+      "type": "string",
+      "title": "Custom Header 2 — Name",
+      "description": "Header name, e.g. X-Tenant. Leave blank to skip this row."
+    },
+    "header_2_value": {
+      "type": "string",
+      "title": "Custom Header 2 — Value",
+      "description": "Header value for the name above. Hidden after entry.",
+      "sensitive": true
+    },
+    "header_3_name": {
+      "type": "string",
+      "title": "Custom Header 3 — Name",
+      "description": "Header name. Leave blank to skip this row."
+    },
+    "header_3_value": {
+      "type": "string",
+      "title": "Custom Header 3 — Value",
+      "description": "Header value for the name above. Hidden after entry.",
+      "sensitive": true
+    },
+    "header_4_name": {
+      "type": "string",
+      "title": "Custom Header 4 — Name",
+      "description": "Header name. Leave blank to skip this row."
+    },
+    "header_4_value": {
+      "type": "string",
+      "title": "Custom Header 4 — Value",
+      "description": "Header value for the name above. Hidden after entry.",
+      "sensitive": true
+    },
+    "header_5_name": {
+      "type": "string",
+      "title": "Custom Header 5 — Name",
+      "description": "Header name. Leave blank to skip this row."
+    },
+    "header_5_value": {
+      "type": "string",
+      "title": "Custom Header 5 — Value",
+      "description": "Header value for the name above. Hidden after entry.",
       "sensitive": true
     }
   },


### PR DESCRIPTION
## Problem

The Authorization header could be specified in three places (CLI, env var, MCPB UI) but the formats were inconsistent and there was no way to specify other custom headers (X-API-Key, tenant IDs, etc.) from the MCPB UI:

| Path | Format |
|---|---|
| CLI `--header` | full header line: `Authorization: Bearer xxx` |
| Env `MCP_AUTH_HEADER` | **value only**: `Bearer xxx` |
| MCPB `Authorization Header` field | value only — but the label and description didn't say so |

The UI field accepted `Authorization: Bearer xxx` literally and produced a broken `Authorization:Authorization: Bearer xxx` header.

## Solution

### MCPB UI
- Renamed the existing field to **`Authorization Header Value`** and rewrote the description to spell out that only the value goes here (`Bearer eyJ...`, `Basic dXNlcjpwYXNz`).
- Added a new **`Custom Headers`** field — `multiline`, `sensitive` — for arbitrary `Name: Value` entries, one per line. Mapped to a new `MCP_HEADERS` env var.

### Binary
- Parse `MCP_HEADERS` (newline-separated, CRLF/LF tolerant). Empty lines and lines without `:` are skipped with a warning so a typo doesn't block valid entries.
- If `MCP_HEADERS` already carries an `Authorization:` line, the legacy `MCP_AUTH_HEADER` is suppressed to avoid duplicates.

### README
Added a "Format notes" table that puts MCPB UI / CLI / env-var formats side by side so the differences are explicit, and documented `MCP_HEADERS` in the env-var table.

## Format reference (now documented)

| Where | Authorization | Other headers |
|---|---|---|
| MCPB UI | `Authorization Header Value` — value only (`Bearer xxx`) | `Custom Headers` — `Name: Value` per line |
| CLI `--header` (repeatable) | `--header "Authorization: Bearer xxx"` | `--header "X-API-Key: secret"` |
| Env vars | `MCP_AUTH_HEADER="Bearer xxx"` (value only) | `MCP_HEADERS=$'X-API-Key: a\nX-Tenant: b'` |

## Test plan

- [x] `go test ./...` — all packages pass
- [x] `make lint` — clean
- [x] `make check` — clean
- [x] `scripts/build-mcpb.sh` — generates valid manifest.json with new field

New tests in `cmd/mcp-remote-go/args_test.go`:
- `TestApplyEnvOverrides_HeadersAppendsMultiple`
- `TestApplyEnvOverrides_HeadersIgnoresBlanksAndInvalidLines` (CRLF + blank + no-colon lines)
- `TestApplyEnvOverrides_HeadersPlusAuthHeaderCombine`
- `TestApplyEnvOverrides_HeadersAuthorizationSuppressesAuthHeader` (regression — no duplicate Authorization)